### PR TITLE
SNAP-656 Delink RDD partitions from buckets 

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -75,10 +75,17 @@ object Partitioner {
  * so attempting to partition an RDD[Array[_]] or RDD[(Array[_], _)] using a HashPartitioner will
  * produce an unexpected or incorrect result.
  */
-class HashPartitioner(partitions: Int, val numBuckets: Int = 0) extends Partitioner {
+class HashPartitioner(partitions: Int, buckets: Int = 0) extends Partitioner {
   require(partitions >= 0, s"Number of partitions ($partitions) cannot be negative.")
+  require(buckets >= 0, s"Number of buckets ($buckets) cannot be negative.")
+
+  def this(partitions: Int) {
+    this(partitions , 0)
+  }
 
   def numPartitions: Int = partitions
+
+  def numBuckets: Int = buckets
 
   def getPartition(key: Any): Int = key match {
     case null => 0

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -75,7 +75,7 @@ object Partitioner {
  * so attempting to partition an RDD[Array[_]] or RDD[(Array[_], _)] using a HashPartitioner will
  * produce an unexpected or incorrect result.
  */
-class HashPartitioner(partitions: Int) extends Partitioner {
+class HashPartitioner(partitions: Int, val numBuckets: Int = 0) extends Partitioner {
   require(partitions >= 0, s"Number of partitions ($partitions) cannot be negative.")
 
   def numPartitions: Int = partitions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -253,9 +253,9 @@ case object SinglePartition extends Partitioning {
  * in the same partition. Moreover while evaluating expressions if they are given in different order
  * than this partitioning then also it is considered equal.
  */
-case class OrderlessHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
+case class OrderlessHashPartitioning(expressions: Seq[Expression],
+    numPartitions: Int, numBuckets: Int)
     extends Expression with Partitioning with Unevaluable {
-
 
   override def children: Seq[Expression] = expressions
   override def nullable: Boolean = false
@@ -274,6 +274,7 @@ case class OrderlessHashPartitioning(expressions: Seq[Expression], numPartitions
   }
 
   private def anyOrderEquals(other: HashPartitioning) : Boolean = {
+    other.numBuckets == this.numBuckets &&
     other.numPartitions == this.numPartitions &&
         matchExpressions(other.expressions)
   }
@@ -284,7 +285,7 @@ case class OrderlessHashPartitioning(expressions: Seq[Expression], numPartitions
   }
 
   override def guarantees(other: Partitioning): Boolean = other match {
-    case o: HashPartitioning => anyOrderEquals(o)
+    case p: HashPartitioning => anyOrderEquals(p)
     case _ => false
   }
 
@@ -295,8 +296,8 @@ case class OrderlessHashPartitioning(expressions: Seq[Expression], numPartitions
  * of `expressions`.  All rows where `expressions` evaluate to the same values are guaranteed to be
  * in the same partition.
  */
-case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
-  extends Expression with Partitioning with Unevaluable {
+case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int,
+    numBuckets : Int = 0 ) extends Expression with Partitioning with Unevaluable {
 
   override def children: Seq[Expression] = expressions
   override def nullable: Boolean = false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use child's numBuckets to decide partitions of shuffled relation in ShuffleExchange
Pass numBuckets to HashPartitioning and HashPartitioner
## How was this patch tested?

Other PRs : 
Store - https://github.com/SnappyDataInc/snappy-store/pull/85
Spark - https://github.com/SnappyDataInc/spark/pull/4
SnppyData - https://github.com/SnappyDataInc/snappydata/pull/297
