### PR TITLE
Double values for decimal datatypes need to be handled correctly.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -775,7 +775,8 @@ case class ValidateExternalType(child: Expression, expected: DataType)
 
     val typeCheck = expected match {
       case _: DecimalType =>
-        Seq(classOf[java.math.BigDecimal], classOf[scala.math.BigDecimal], classOf[Decimal])
+        Seq(classOf[java.math.BigDecimal], classOf[scala.math.BigDecimal], classOf[Decimal],
+          classOf[java.lang.Double])
           .map(cls => s"$obj instanceof ${cls.getName}").mkString(" || ")
       case _: ArrayType =>
         s"$obj instanceof ${classOf[Seq[_]].getName} || $obj.getClass().isArray()"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -409,6 +409,9 @@ object Decimal {
 
   def apply(value: String): Decimal = new Decimal().set(BigDecimal(value))
 
+  def apply(value: java.lang.Double): Decimal =
+    new Decimal().set(BigDecimal(value))
+
   // This is used for RowEncoder to handle Decimal inside external row.
   def fromDecimal(value: Any): Decimal = {
     value match {
@@ -416,6 +419,7 @@ object Decimal {
       case d: BigDecimal => apply(d)
       case k: scala.math.BigInt => apply(k)
       case l: java.math.BigInteger => apply(l)
+      case dob: java.lang.Double => apply(dob)
       case d: Decimal => d
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found that with 2.0 merge my test are failing due to different handling of decimal datatype.

To see problem "test no routing even with HAC reroute" of QueryRoutingTestSuite on branch decimal2.0merge (aqp brnach) is failing without proposed changes.

I also noticed that earlier blank values was inserted in table as null of double or null of decimal but now they are only inserted as string. Interestingly this decision is taken based on values in first row. I did not address this problem and rather changed test (Commit: 007298a280bdc6086736e35eaf9a24b0056b3ab6). But I guess other test are still failing for same reason and need to be addressed at some point. 
## How was this patch tested?

Running above test suite. If approved will do a precheckin (currently many tests are failing)
