### PR TITLE
SNAP-1281: UI does not show up if spark shell is run without snappydata

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -72,7 +72,7 @@ class SparkUI private (
     attachTab(new EnvironmentTab(this))
     attachTab(new ExecutorsTab(this))
     attachHandler(createStaticHandler(SparkUI.STATIC_RESOURCE_DIR, "/static"))
-    // attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
+    attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
     attachHandler(ApiRootResource.getServletHandler(this))
     // This should be POST only, but, the YARN AM proxy won't proxy POSTs
     attachHandler(createRedirectHandler(


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Re-enabling the default spark redirection handler to redirect user to spark jobs page.


## How was this patch tested?

* Tested Manually

