### PR TITLE
Aqp 271

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -110,6 +110,27 @@ case class AggregateExpression(
   extends Expression
   with Unevaluable {
 
+
+  def equalsTo(agg: AggregateExpression): Boolean = {
+      agg.eq(this) || (aggregateFunction.equals(agg.aggregateFunction) &&
+        mode.equals(agg.mode) && isDistinct == agg.isDistinct)
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case agg: AggregateExpression => this.equalsTo(agg)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    var result = 113
+    result = 37*result + aggregateFunction.hashCode()
+    result = 37*result + mode.hashCode()
+    result = 37*result + (if (isDistinct) 1 else 0)
+    result
+  }
+
   lazy val resultAttribute: Attribute = if (aggregateFunction.resolved) {
     AttributeReference(
       aggregateFunction.toString,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -110,6 +110,10 @@ case class AggregateExpression(
   extends Expression
   with Unevaluable {
 
+  private lazy val _hashCode: Int = scala.util.hashing.MurmurHash3.productHash(
+    (aggregateFunction, mode, isDistinct))
+
+  override def hashCode(): Int = _hashCode
 
   def equalsTo(agg: AggregateExpression): Boolean = {
       agg.eq(this) || (aggregateFunction.equals(agg.aggregateFunction) &&
@@ -123,13 +127,7 @@ case class AggregateExpression(
     }
   }
 
-  override def hashCode(): Int = {
-    var result = 113
-    result = 37*result + aggregateFunction.hashCode()
-    result = 37*result + mode.hashCode()
-    result = 37*result + (if (isDistinct) 1 else 0)
-    result
-  }
+
 
   lazy val resultAttribute: Attribute = if (aggregateFunction.resolved) {
     AttributeReference(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -273,7 +273,8 @@ object PhysicalAggregation {
           case ae: AggregateExpression =>
             // The final aggregation buffer's attributes will be `finalAggregationAttributes`,
             // so replace each aggregate expression by its corresponding attribute in the set:
-            ae.resultAttribute
+            aggregateExpressions.find(_ == ae).get.resultAttribute
+           // ae.resultAttribute
           case expression =>
             // Since we're using `namedGroupingAttributes` to extract the grouping key
             // columns, we need to replace grouping key expressions with their corresponding


### PR DESCRIPTION
Looks like in Spark 2.0 the optimization of repeat aggregates being represented by a single aggregate was broken because of passing of resultId: ExprID in the constructor of AggregateExpression. Thus if the query is of type
select avg(x), y from tab group by y having avg(x) > 0
ideally there should be only 1 aggregate evaluated . But since the resultID passed is different in the analyze phase, the distinct on aggregateExpressions, does not result in 1 aggregate .
The change is to implement the equality/hashCode method of aggregate expression instead of relying on scala case class generated methods. and ensuring the dependency on the aggregate which gets removed, is correctly rewritten. The test for this bug is present in CommonBugTest of aqp in AQP-271 branch

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

