### PR TITLE
[SNAP-1486] change QueryPlan.cleanArgs to transient lazy val

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -97,7 +97,7 @@ private[spark] class TaskContextImpl(
         listener.onTaskCompletion(this)
       } catch {
         case e: Throwable =>
-          errorMsgs += e.getMessage
+          errorMsgs += Utils.exceptionString(e)
           logError("Error in TaskCompletionListener", e)
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -411,7 +411,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   }
 
   /** Args that have cleaned such that differences in expression id should not affect equality */
-  protected lazy val cleanArgs: Seq[Any] = {
+  @transient protected lazy val cleanArgs: Seq[Any] = {
     def cleanArg(arg: Any): Any = arg match {
       // Children are checked using sameResult above.
       case tn: TreeNode[_] if containsChild(tn) => null


### PR DESCRIPTION
## What changes were proposed in this pull request?

cleanArgs can end up holding transient fields of the class. These need not be serialized
with the plan and can be recalculated on the other side if required.

Also added full exception stack for cases of task listener failures.

## How was this patch tested?

precheckin
