### PR TITLE
SNAP-1744:  UI itself needs to consistently refer to itself as "SnappyData Pulse".

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
@@ -4,6 +4,16 @@
  ==========================================================================
 */
 
+.UIName {
+    line-height: 2.5;
+    vertical-align: middle;
+    font-size: 20px;
+    padding: 0;
+    margin: 0;
+    font-weight: bold;
+    color: #777;
+}
+
 /*
 .keyStates {
   float: left;

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -247,13 +247,10 @@ private[spark] object UIUtils extends Logging {
             <div class="brand">
               <a href={prependBaseUri("/")} class="brand">
                 <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
+                {getProductUINameNode}
                 {getProductVersionNode}
               </a>
             </div>
-            <p class="navbar-text pull-right">
-              <strong title={appName}>{shortAppName}</strong> application UI
-            </p>
             {getProductDocLinkNode()}
             <ul class="nav">{header}</ul>
           </div>
@@ -303,13 +300,10 @@ private[spark] object UIUtils extends Logging {
             <div class="brand">
               <a href={prependBaseUri("/")} class="brand">
                 <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
+                {getProductUINameNode}
                 {getProductVersionNode}
               </a>
             </div>
-            <p class="navbar-text pull-right">
-              <strong title={appName}>{shortAppName}</strong> application UI
-            </p>
             {getProductDocLinkNode()}
             <ul class="nav">{header}</ul>
           </div>
@@ -351,13 +345,10 @@ private[spark] object UIUtils extends Logging {
             <div class="brand">
               <a href={prependBaseUri("/")} class="brand">
                 <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
+                {getProductUINameNode}
                 {getProductVersionNode}
               </a>
             </div>
-            <p class="navbar-text pull-right">
-              <strong title={appName}>{shortAppName}</strong> application UI
-            </p>
             {getProductDocLinkNode()}
             <ul class="nav">{header}</ul>
           </div>
@@ -635,6 +626,11 @@ private[spark] object UIUtils extends Logging {
 
     <span class="version" style="font-size: 14px;" data-toggle="tooltip" data-placement="bottom"
           data-original-title={versionTooltipText} > {SparkUI.getProductVersion} </span>
+  }
+
+  def getProductUINameNode(): Node = {
+    <span class="UIName" data-toggle="tooltip" data-placement="bottom"
+          data-original-title="SnappyData Monitoring Application"> Pulse </span>
   }
 
   def getProductDocLinkNode(): Node = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - Label "Pulse" is added on snappyData UI just besides SnappyData Logo.

## How was this patch tested?

 - Tested Manually

Please review http://spark.apache.org/contributing.html before opening a pull request.
