### PR TITLE
Support for setting scheduler pools using the set command 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -676,6 +676,8 @@ class SparkSession private(
     }
   }
 
+  def confCallback(key: String, value: String) = {}
+
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/SetCommand.scala
@@ -64,6 +64,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
     case Some((key, Some(value))) =>
       val runFunc = (sparkSession: SparkSession) => {
         sparkSession.conf.set(key, value)
+        sparkSession.confCallback(key, value)
         Seq(Row(key, value))
       }
       (keyValueOutput, runFunc)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a call back when set command is called. This can be used to execute some code when a particular property is set. For now this will be used for setting the scheduler pools in Snappy's code. 

## How was this patch tested?
Manual testing.
Precheckin. 

# Related PR
https://github.com/SnappyDataInc/snappydata/pull/692/

