### PR TITLE
Fix from Hemant for failing :docs target during precheckin run

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -119,9 +119,6 @@ dependencies {
   compile group: 'org.glassfish.jersey.core', name: 'jersey-server', version: jerseyVersion
   compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
   compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: jerseyVersion
-  compile(group: 'org.apache.mesos', name: 'mesos', version: '0.21.1', classifier: 'shaded-protobuf') {
-    exclude(group: 'com.google.protobuf', module: 'protobuf-java')
-  }
   compile group: 'io.netty', name: 'netty-all', version: nettyAllVersion
   compile(group: 'com.clearspring.analytics', name: 'stream', version: '2.7.0') {
     exclude(group: 'it.unimi.dsi', module: 'fastutil')


### PR DESCRIPTION
## What changes were proposed in this pull request?
After spark 2.1 merge :docs started failing in precheckin run.

Hemant noticed that Apache spark 2.1 do not refer Mesos now (see its pom.xml) but snappy spark still refer Mesos which have been removed.

## How was this patch tested?
:docs
precheckin

