### PR TITLE
[SNAP-1389] Optimized UTF8String.compareTo

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1072,7 +1072,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         final long rl = getLongBigEndian(rightBase, rightOffset);
         final long res = ll - rl;
         // If the sign of both values is same then "res" is with correct sign.
-        // If the sign of values if different then "res" has opposite sign.
+        // If the sign of values is different then "res" has opposite sign.
         // The XOR operations will revert the sign bit of res if sign of values is different.
         // After that converting to signum is "(1 + ((v >> 63) << 1)).toInt"
         //   where (v >> 63) will flow the sign to give -1 or 0, and (1 + 2 times)

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1071,7 +1071,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         final long ll = getLongBigEndian(leftBase, leftOffset);
         final long rl = getLongBigEndian(rightBase, rightOffset);
         final long res = ll - rl;
-        // If the sign of both values is same then the "res" is with correct sign.
+        // If the sign of both values is same then "res" is with correct sign.
         // If the sign of values if different then "res" has opposite sign.
         // The XOR operations will revert the sign bit of res if sign of values is different.
         // After that converting to signum is "(1 + ((v >> 63) << 1)).toInt"

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1071,10 +1071,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         final long ll = getLongBigEndian(leftBase, leftOffset);
         final long rl = getLongBigEndian(rightBase, rightOffset);
         final long res = ll - rl;
-        // If the sign of both values is same then get the "res" is with correct sign.
+        // If the sign of both values is same then the "res" is with correct sign.
         // If the sign of values if different then "res" has opposite sign.
         // The XOR operations will revert the sign bit of res if sign of values is different.
         // After that converting to signum is "(1 + ((v >> 63) << 1)).toInt"
+        //   where (v >> 63) will flow the sign to give -1 or 0, and (1 + 2 times)
+        //   of that will give -1 or 1 respectively.
         if (res != 0) return (int)(1 + (((ll ^ rl ^ res) >> 63) << 1));
         leftOffset += 8;
         rightOffset += 8;

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -67,7 +67,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     5, 5, 5, 5,
     6, 6};
 
-  private static boolean isLittleEndian = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+  private static final boolean isLittleEndian = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   private static final UTF8String COMMA_UTF8 = UTF8String.fromString(",");
   public static final UTF8String EMPTY_UTF8 = UTF8String.fromString("");
@@ -1043,15 +1043,61 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return compare(other);
   }
 
-  public int compare(final UTF8String other) {
-    int len = Math.min(numBytes, other.numBytes);
-    // TODO: compare 8 bytes as unsigned long
-    for (int i = 0; i < len; i ++) {
-      // In UTF-8, the byte should be unsigned, so we should compare them as unsigned int.
-      int res = (getByte(i) & 0xFF) - (other.getByte(i) & 0xFF);
-      if (res != 0) {
-        return res;
+  /** Read integer in big-endian format */
+  static int getIntBigEndian(final Object base, final long offset) {
+    return isLittleEndian ? Integer.reverseBytes(Platform.getInt(base, offset))
+        : Platform.getInt(base, offset);
+  }
+
+  /** Read long in big-endian format */
+  static long getLongBigEndian(final Object base, final long offset) {
+    return isLittleEndian ? Long.reverseBytes(Platform.getLong(base, offset))
+        : Platform.getLong(base, offset);
+  }
+
+  public final int compare(final UTF8String other) {
+    final Object rightBase = other.getBaseObject();
+    long rightOffset = other.getBaseOffset();
+    final Object leftBase = base;
+    long leftOffset = offset;
+
+    final int len = Math.min(numBytes, other.numBytes);
+    long endOffset = leftOffset + len;
+    // for architectures that support unaligned accesses, read 8 bytes at a time
+    if (Platform.unaligned() || (((leftOffset & 0x7) == 0) && ((rightOffset & 0x7) == 0))) {
+      endOffset -= 8;
+      while (leftOffset <= endOffset) {
+        // In UTF-8, the byte should be unsigned, so we should compare them as unsigned long.
+        final long ll = getLongBigEndian(leftBase, leftOffset);
+        final long rl = getLongBigEndian(rightBase, rightOffset);
+        final long res = ll - rl;
+        // If the sign of both values is same then get the "res" is with correct sign.
+        // If the sign of values if different then "res" has opposite sign.
+        // The XOR operations will revert the sign bit of res if sign of values is different.
+        // After that converting to signum is "(1 + ((v >> 63) << 1)).toInt"
+        if (res != 0) return (int)(1 + (((ll ^ rl ^ res) >> 63) << 1));
+        leftOffset += 8;
+        rightOffset += 8;
       }
+      endOffset += 4;
+      if (leftOffset <= endOffset) {
+        // In UTF-8, the byte should be unsigned, so we should compare them as unsigned int.
+        final long res = (getIntBigEndian(leftBase, leftOffset) & 0xffffffffL) -
+            (getIntBigEndian(rightBase, rightOffset) & 0xffffffffL);
+        if (res != 0) return (int)(1 + ((res >> 63) << 1));
+        leftOffset += 4;
+        rightOffset += 4;
+      }
+      endOffset += 4;
+    }
+    // finish the remaining bytes
+    while (leftOffset < endOffset) {
+      // In UTF-8, the byte should be unsigned, so we should compare them as unsigned int.
+      final int res = (Platform.getByte(leftBase, leftOffset) & 0xff) -
+          (Platform.getByte(rightBase, rightOffset) & 0xff);
+      if (res != 0) return res;
+      leftOffset++;
+      rightOffset++;
     }
     return numBytes - other.numBytes;
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1074,7 +1074,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         // If the sign of both values is same then "res" is with correct sign.
         // If the sign of values is different then "res" has opposite sign.
         // The XOR operations will revert the sign bit of res if sign of values is different.
-        // After that converting to signum is "(1 + ((v >> 63) << 1)).toInt"
+        // After that converting to signum is "(1 + ((v >> 63) << 1))"
         //   where (v >> 63) will flow the sign to give -1 or 0, and (1 + 2 times)
         //   of that will give -1 or 1 respectively.
         if (res != 0) return (int)(1 + (((ll ^ rl ^ res) >> 63) << 1));
@@ -1083,7 +1083,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       }
       endOffset += 4;
       if (leftOffset <= endOffset) {
-        // In UTF-8, the byte should be unsigned, so we should compare them as unsigned int.
+        // In UTF-8, the byte should be unsigned, so we should compare them as unsigned int
+        // which is done by converting to unsigned longs.
+        // After that conversion to signed integer is "(1 + ((v >> 63) << 1))" as above.
         final long res = (getIntBigEndian(leftBase, leftOffset) & 0xffffffffL) -
             (getIntBigEndian(rightBase, rightOffset) & 0xffffffffL);
         if (res != 0) return (int)(1 + ((res >> 63) << 1));


### PR DESCRIPTION
As part of performance testing for SNAP-1389, it was seen that UTF8String.compare could be optimized quite a bit. The upstream code already contains comment "// TODO: compare 8 bytes as unsigned long". This PR completes that TODO as well as adds other changes taking from previous ByteArrayMethods.arrayEquals optimizations.

## What changes were proposed in this pull request?

- use unsigned long comparisons, followed by unsigned int comparison if possible,
  before finishing with unsigned byte comparisons for best performance
- use big-endian long/int for comparisons since it requires the lower-index bytes to be in MSB
- no alignment attempted since we expect most cases to fail early in first long comparison itself

For a comparison see the code of [ByteArrayMethods.arrayEquals](https://github.com/SnappyDataInc/spark/blob/snappy/branch-2.1/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java#L47). As noted above, alignment is not attempted because we expect most comparisons to fail and within first few bytes so alignment will unnecessarily end up doing byte-by-byte comparisons in most cases. This is also seen in sort micro-benchmarks which see a 20% drop in performance with alignment code. By contrast alignment is very useful for UTF8String.equals since in hashing we expect most cases to be successful match after hashcode has already been matched.

In general the comparison itself is ~2X faster with these changes. Following is the comparison in micro-benchmarks (in snappydata PR).

### Random strings

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_131-b11 on Linux 4.4.0-21-generic
Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz

Sort num=10M distinct=1K:        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------
Spark                                 4651 / 4674          2.1         465.1       1.0X
Snappy                                3579 / 3599          2.8         357.9       1.3X

Sort num=10M distinct=10M:        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------
Spark                               11225 / 11590          0.9        1122.5       1.0X
Snappy                                9536 / 9852          1.0         953.6       1.2X
```

The first case where number of distinct values is smaller compared to total number of values sees a bit more gain than the second case where all values are distinct due to large number of bytes required to be compared on an average.

Here the numbers are dominated by cache misses so the gains are smaller. For arrays that are already mostly sorted, the numbers are dominated by comparison performance:

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_131-b11 on Linux 4.4.0-21-generic
Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz

Sort(pre-sorted) num=10M distinct=1K:  Best/Avg Time(ms)  Rate(M/s)  Per Row(ns)  Relative
-----------------------------------------------------------------------------------------
Spark                                   1917 / 1935          5.2         191.7       1.0X
Snappy                                   840 /  845         11.9          84.0       2.3X

Sort(pre-sorted) num=10M distinct=10M: Best/Avg Time(ms)  Rate(M/s)  Per Row(ns)  Relative
------------------------------------------------------------------------------------------
Spark                                   1687 / 1753          5.9         168.7       1.0X
Snappy                                   736 /  758         13.6          73.6       2.3X
```

## How was this patch tested?

precheckin, test checking for sorting results of random strings, local tests comparing performance (in snappydata PR)