### PR TITLE
SNAP-1744: UI itself needs to consistently refer to itself as "SnappyData Pulse"

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
@@ -4,6 +4,16 @@
  ==========================================================================
 */
 
+.UIName {
+  line-height: 2.5;
+  vertical-align: middle;
+  font-size: 20px;
+  padding: 0;
+  margin: 0;
+  font-weight: bold;
+  color: #3CA881;
+}
+
 /*
 .keyStates {
   float: left;

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -596,7 +596,9 @@ private[spark] object UIUtils extends Logging {
   }
 
   def getProductUINameNode(): Node = {
-    <span class="UIName" data-toggle="tooltip" data-placement="bottom"
+    <span style="line-height: 2.5; vertical-align: middle; font-size: 20px; padding: 0;
+          margin: 0; font-weight: bold; color: #3CA881;" data-toggle="tooltip"
+          data-placement="bottom"
           data-original-title="SnappyData Monitoring Application"> Pulse </span>
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -161,8 +161,6 @@ private[spark] object UIUtils extends Logging {
     <link rel="stylesheet" href={prependBaseUri("/static/vis.min.css")} type="text/css"/>
     <link rel="stylesheet" href={prependBaseUri("/static/webui.css")} type="text/css"/>
     <link rel="stylesheet" href={prependBaseUri("/static/timeline-view.css")} type="text/css"/>
-    <link rel="stylesheet" href={prependBaseUri("/static/snappydata/snappy-dashboard.css")}
-          type="text/css"/>
     <script src={prependBaseUri("/static/sorttable.js")} ></script>
     <script src={prependBaseUri("/static/jquery-1.11.1.min.js")}></script>
     <script src={prependBaseUri("/static/vis.min.js")}></script>
@@ -176,23 +174,9 @@ private[spark] object UIUtils extends Logging {
     <script>setUIRoot('{UIUtils.uiRoot}')</script>
   }
 
-  def commonHeaderNodes_2: Seq[Node] = {
-      <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-      <link rel="stylesheet" href={prependBaseUri("/static/bootstrap.min.css")} type="text/css"/>
-      <link rel="stylesheet" href={prependBaseUri("/static/vis.min.css")} type="text/css"/>
-      <link rel="stylesheet" href={prependBaseUri("/static/webui.css")} type="text/css"/>
-      <link rel="stylesheet" href={prependBaseUri("/static/timeline-view.css")} type="text/css"/>
+  def commonHeaderNodesSnappy: Seq[Node] = {
       <link rel="stylesheet" href={prependBaseUri("/static/snappydata/snappy-dashboard.css")}
             type="text/css"/>
-      <script src={prependBaseUri("/static/sorttable.js")} ></script>
-      <script src={prependBaseUri("/static/jquery-1.11.1.min.js")}></script>
-      <script src={prependBaseUri("/static/vis.min.js")}></script>
-      <script src={prependBaseUri("/static/bootstrap-tooltip.js")}></script>
-      <script src={prependBaseUri("/static/initialize-tooltips.js")}></script>
-      <script src={prependBaseUri("/static/table.js")}></script>
-      <script src={prependBaseUri("/static/additional-metrics.js")}></script>
-      <script src={prependBaseUri("/static/timeline-view.js")}></script>
-      <script src={prependBaseUri("/static/log-view.js")}></script>
       <script src={prependBaseUri("/static/snappydata/d3.js")}></script>
       <script src={prependBaseUri("/static/snappydata/liquidFillGauge.js")}></script>
       <script src={prependBaseUri("/static/snappydata/snappy-dashboard.js")}></script>
@@ -253,7 +237,7 @@ private[spark] object UIUtils extends Logging {
             <div class="brand">
               <a href={prependBaseUri("/")} class="brand">
                 <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
+                {getProductUINameNode}
                 {getProductVersionNode}
               </a>
             </div>
@@ -300,6 +284,7 @@ private[spark] object UIUtils extends Logging {
     <html>
       <head>
         {commonHeaderNodes}
+        {commonHeaderNodesSnappy}
         {if (showVisualization) vizHeaderNodes else Seq.empty}
         <title>{appName} - {title}</title>
       </head>
@@ -309,55 +294,7 @@ private[spark] object UIUtils extends Logging {
             <div class="brand">
               <a href={prependBaseUri("/")} class="brand">
                 <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
-                {getProductVersionNode}
-              </a>
-            </div>
-            <p class="navbar-text pull-right">
-              <strong title={appName}>{shortAppName}</strong> application UI
-            </p>
-            {getProductDocLinkNode()}
-            <ul class="nav">{header}</ul>
-          </div>
-        </div>
-        <div class="container-fluid">
-          {content}
-        </div>
-      </body>
-    </html>
-  }
-
-  /** Returns a simple spark page with correctly formatted tabs */
-  def simpleSparkPageWithTabs_2(
-      title: String,
-      content: => Seq[Node],
-      activeTab: SparkUITab,
-      refreshInterval: Option[Int] = None,
-      helpText: Option[String] = None,
-      showVisualization: Boolean = false): Seq[Node] = {
-
-    val appName = activeTab.appName
-    val shortAppName = if (appName.length < 36) appName else appName.take(32) + "..."
-    val header = activeTab.headerTabs.map { tab =>
-      <li class={if (tab == activeTab) "active" else ""}>
-        <a href={prependBaseUri(activeTab.basePath, "/" + tab.prefix + "/")}>{tab.name}</a>
-      </li>
-    }
-    // val helpButton: Seq[Node] = helpText.map(tooltip(_, "bottom")).getOrElse(Seq.empty)
-
-    <html>
-      <head>
-        {commonHeaderNodes_2}
-        {if (showVisualization) vizHeaderNodes else Seq.empty}
-        <title>{appName} - {title}</title>
-      </head>
-      <body>
-        <div class="navbar navbar-static-top">
-          <div class="navbar-inner">
-            <div class="brand">
-              <a href={prependBaseUri("/")} class="brand">
-                <img src={prependBaseUri("/static/snappydata/SnappyData-Logo-230X50.png")} />
-                <!-- <span class="version">{org.apache.spark.SPARK_VERSION}</span> -->
+                {getProductUINameNode}
                 {getProductVersionNode}
               </a>
             </div>
@@ -653,8 +590,14 @@ private[spark] object UIUtils extends Logging {
       "SnappyData Ver. " + SparkUI.getProductVersion + " ( Underlying Spark Ver. " +
           org.apache.spark.SPARK_VERSION + " )"
 
-    <span class="version" style="font-size: 14px;" data-toggle="tooltip" data-placement="bottom"
+    <span class="version" style="font-size: 14px; color: #3CA881;" data-toggle="tooltip"
+          data-placement="bottom"
           data-original-title={versionTooltipText} > {SparkUI.getProductVersion} </span>
+  }
+
+  def getProductUINameNode(): Node = {
+    <span class="UIName" data-toggle="tooltip" data-placement="bottom"
+          data-original-title="SnappyData Monitoring Application"> Pulse </span>
   }
 
   def getProductDocLinkNode(): Node = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - SnappyData Dashboard UI displays its name as SnappyData Pulse.
 - Code refactoring and code clean up.

## How was this patch tested?

- Tested Manually.
