### PR TITLE
[SNAP-1951] move authentication handler bind to be inside connect

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -309,13 +309,6 @@ private[spark] object JettyUtils extends Logging {
 
     val gzipHandlers = handlers.map { h =>
       h.setVirtualHosts(Array("@" + SPARK_CONNECTOR_NAME))
-      // set Security Handler
-      customAuthenticator match {
-        case Some(auth) =>
-          h.setSecurityHandler(basicAuthenticationHandler())
-        case None =>
-          logDebug("Not setting auth handler")
-      }
       val gzipHandler = new GzipHandler
       gzipHandler.setHandler(h)
       gzipHandler
@@ -328,6 +321,18 @@ private[spark] object JettyUtils extends Logging {
         pool.setName(serverName)
       }
       pool.setDaemon(true)
+
+      // Set SnappyData authenticator into the SecurityHandler
+      // Has to be done inside connect because a failure to bind to port will
+      // clear the handler so auth will fail even if bind on next port succeeds.
+      customAuthenticator match {
+        case Some(_) =>
+          gzipHandlers.foreach { gh =>
+            gh.getHandler.asInstanceOf[ServletContextHandler]
+                .setSecurityHandler(basicAuthenticationHandler())
+          }
+        case None => logDebug("Not setting auth handler")
+      }
 
       val server = new Server(pool)
       val connectors = new ArrayBuffer[ServerConnector]()

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -322,7 +322,7 @@ private[spark] object JettyUtils extends Logging {
       }
       pool.setDaemon(true)
 
-      // Set SnappyData authenticator into the SecurityHandler
+      // Set SnappyData authenticator into the SecurityHandler.
       // Has to be done inside connect because a failure to bind to port will
       // clear the handler so auth will fail even if bind on next port succeeds.
       customAuthenticator match {


### PR DESCRIPTION
Found a bunch of product issues when converting the precheckin runs to use parallel tasks. This is one of them where security tests fail to bind to default 5050 port (since it is occupied by another test) then fail with IllegalStateException due to missing loginService.

## What changes were proposed in this pull request?

When bind to default 5050 port fails, then code clears the loginService inside
SecurityHandler.close causing the next attempt on 5051 to fail with
"IllegalStateException: No LoginService for SnappyBasicAuthenticator".

This moves the authentication handler setting inside the connect method.

## How was this patch tested?

parallel precheckin
