### PR TITLE
Added code to dump generated code in case of exception

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -266,6 +266,7 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with CodegenSupp
 
 object WholeStageCodegenExec {
   val PIPELINE_DURATION_METRIC = "duration"
+  val dumpGenCodeForException = System.getProperty("spark.dumpGenCode", "true").toBoolean
 }
 
 /**
@@ -515,7 +516,9 @@ case class WholeStageCodegenRDD(@transient sc: SparkContext, var source: CodeAnd
         }
       } catch {
         case e: Throwable =>
-          logError(s"\n${CodeFormatter.format(source)}")
+          if (WholeStageCodegenExec.dumpGenCodeForException) {
+            logError(s"\n${CodeFormatter.format(source)}")
+          }
           throw e
       }
 
@@ -523,7 +526,9 @@ case class WholeStageCodegenRDD(@transient sc: SparkContext, var source: CodeAnd
         iter.next()
       } catch {
         case e: Throwable =>
-          logError(s"\n${CodeFormatter.format(source)}")
+          if (WholeStageCodegenExec.dumpGenCodeForException) {
+            logError(s"\n${CodeFormatter.format(source)}")
+          }
           throw e
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added code to dump generated code in case of exception in the server side. hasNext function of the iterator is the one that fails in case of an excpetion. Added exception handling for next as well, just in case. 

## How was this patch tested?

Manual. Precheckin. 