### PR TITLE
[SNAP-1993] Optimize UTF8String.contains

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.unsafe;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.security.CodeSource;
+import java.util.Locale;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Optimized JNI calls.
+ */
+public final class Native {
+
+  public static final int MIN_JNI_SIZE = 32;
+
+  public static final boolean debug;
+  private static final Logger logger;
+
+  private static final boolean is64Bit;
+  private static final boolean isSolaris;
+  private static final boolean nativeLoaded;
+
+  private Native() {
+  }
+
+  static {
+    debug = Boolean.getBoolean("spark.native.debug");
+
+    String arch = System.getProperty("os.arch");
+    is64Bit = arch.contains("64") || arch.contains("s390x");
+    String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+    isSolaris = os.contains("sunos") || os.contains("solaris");
+
+    logger = Logger.getLogger(Native.class);
+
+    String library = isSolaris() ? "native_sol" : "native";
+    if (is64Bit()) {
+      library += "64";
+    }
+    if (debug) {
+      library += "_g";
+    }
+
+    boolean loaded = false;
+    CodeSource cs = Native.class.getProtectionDomain().getCodeSource();
+    URL jarURL = cs != null ? cs.getLocation() : null;
+    String libDir;
+    try {
+      if (jarURL != null) {
+        libDir = new File(URLDecoder.decode(jarURL.getFile(), "UTF-8"))
+            .getParentFile().getCanonicalPath();
+      } else {
+        // try in SNAPPY_HOME and SPARK_HOME
+        String productHome = System.getenv("SNAPPY_HOME");
+        if (productHome == null) {
+          productHome = System.getenv("SPARK_HOME");
+        }
+        if (productHome == null) {
+          throw new IllegalStateException("Unable to locate jar location");
+        }
+        libDir = new File(productHome, "jars").getCanonicalPath();
+      }
+      File libraryPath = new File(libDir, System.mapLibraryName(library));
+      if (libraryPath.exists()) {
+        System.load(libraryPath.getPath());
+        logger.info("library " + library + " loaded from " + libraryPath);
+      } else {
+        System.loadLibrary(library);
+        logger.info("library " + library + " loaded from system path");
+      }
+
+      loaded = true;
+    } catch (IOException ioe) {
+      throw new IllegalStateException(ioe);
+    } catch (UnsatisfiedLinkError ule) {
+      if (logger.isInfoEnabled()) {
+        logger.info("library " + library + " could not be loaded");
+      }
+    }
+    nativeLoaded = loaded;
+  }
+
+  public static boolean is64Bit() {
+    return is64Bit;
+  }
+
+  public static boolean isSolaris() {
+    return isSolaris;
+  }
+
+  public static boolean isLoaded() {
+    return nativeLoaded;
+  }
+
+  public static native boolean arrayEquals(long leftAddress,
+      long rightAddress, long size);
+
+  public static native boolean containsString(long sourceAddress,
+      long sourceEnd, long destAddress, int destSize);
+}

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
@@ -90,7 +90,9 @@ public final class Native {
 
       loaded = true;
     } catch (IOException ioe) {
-      throw new IllegalStateException(ioe);
+      if (logger.isInfoEnabled()) {
+        logger.info("library " + library + " could not be loaded due to " + ioe);
+      }
     } catch (UnsatisfiedLinkError ule) {
       if (logger.isInfoEnabled()) {
         logger.info("library " + library + " could not be loaded");

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.unsafe.array;
 
+import org.apache.spark.unsafe.Native;
 import org.apache.spark.unsafe.Platform;
 
 public class ByteArrayMethods {
@@ -46,6 +47,10 @@ public class ByteArrayMethods {
    */
   public static boolean arrayEquals(final Object leftBase, long leftOffset,
       final Object rightBase, long rightOffset, final long length) {
+    if (leftBase == null && rightBase == null &&
+        length > Native.MIN_JNI_SIZE && Native.isLoaded()) {
+      return Native.arrayEquals(leftOffset, rightOffset, length);
+    }
     long endOffset = leftOffset + length;
     // try to align at least one side
     if ((rightOffset & 0x7) != 0 && (leftOffset & 0x7) != 0) { // mod 8

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -30,6 +30,7 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import org.apache.spark.unsafe.Native;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.array.ByteArrayMethods;
 import org.apache.spark.unsafe.hash.Murmur3_x86_32;
@@ -289,18 +290,25 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Returns whether this contains `substring` or not.
    */
   public boolean contains(final UTF8String substring) {
-    final int len = substring.numBytes;
-    if (len == 0) {
+    final int slen = substring.numBytes;
+    if (slen == 0) {
       return true;
     }
 
-    final byte first = substring.getByte(0);
     final Object base = this.base;
+    final int len = this.numBytes;
+    // noinspection ConstantConditions
+    if (base == null && len > Native.MIN_JNI_SIZE &&
+        substring.base == null && Native.isLoaded()) {
+      return Native.containsString(offset, offset + len, substring.offset, slen);
+    }
+
+    final byte first = substring.getByte(0);
     long offset = this.offset;
-    final long end = offset + numBytes - len;
+    final long end = offset + len - slen;
     for (; offset <= end; offset++) {
       if (Platform.getByte(base, offset) == first && ByteArrayMethods.arrayEquals(
-          base, offset, substring.base, substring.offset, len)) return true;
+          base, offset, substring.base, substring.offset, slen)) return true;
     }
     return false;
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -289,15 +289,18 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Returns whether this contains `substring` or not.
    */
   public boolean contains(final UTF8String substring) {
-    if (substring.numBytes == 0) {
+    final int len = substring.numBytes;
+    if (len == 0) {
       return true;
     }
 
-    byte first = substring.getByte(0);
-    for (int i = 0; i <= numBytes - substring.numBytes; i++) {
-      if (getByte(i) == first && matchAt(substring, i)) {
-        return true;
-      }
+    final byte first = substring.getByte(0);
+    final Object base = this.base;
+    long offset = this.offset;
+    final long end = offset + numBytes - len;
+    for (; offset <= end; offset++) {
+      if (Platform.getByte(base, offset) == first && ByteArrayMethods.arrayEquals(
+          base, offset, substring.base, substring.offset, len)) return true;
     }
     return false;
   }
@@ -309,7 +312,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return Platform.getByte(base, offset + i);
   }
 
-  private boolean matchAt(final UTF8String s, int pos) {
+  public boolean matchAt(final UTF8String s, int pos) {
     if (s.numBytes + pos > numBytes || pos < 0) {
       return false;
     }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -312,7 +312,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return Platform.getByte(base, offset + i);
   }
 
-  public boolean matchAt(final UTF8String s, int pos) {
+  private boolean matchAt(final UTF8String s, int pos) {
     if (s.numBytes + pos > numBytes || pos < 0) {
       return false;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimized version of UTF8String.contains that improves performance by ~40%.
However, it is still ~3X slower than JDK String.contains that perhaps uses JVM intrinsics
(checked with a copy of the code from rt sources and it is slower than the new
 UTF8String.contains).

Also added hook for a more efficient JNI version to be added later when "haystack" string is decently large (>32 chars).

Below comparison is using customers.csv treating full row as a single string and searching within it. See "UTF8String optimized contains" in StringBenchmark.

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_144-b01 on Linux 4.10.0-33-generic
Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz
compare contains:                        Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
UTF8String (orig)                              241 /  243          4.7         214.4       1.0X
UTF8String (opt)                               133 /  137          8.4         118.4       1.8X
String                                          97 /   99         11.6          86.4       2.5X
Regex                                          267 /  278          4.2         237.5       0.9X
```

The changes that make the difference are:

- local offset counter instead of getByte(i) calls that reads the base, offset repeatedly
- matchAt() has checks that are not required because its already ensured in the limits for the current position (also reads the base, offset again)

## How was this patch tested?

Benchmark test in snappydata
