### PR TITLE
Fix to avoid dumping of gen code in case of low memory exception. 

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.apache.spark.sql.execution
-
 
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import java.sql.SQLException
+
 import org.apache.spark.{broadcast, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.{RDD, ZippedPartitionsBaseRDD, ZippedPartitionsPartition}
 import org.apache.spark.sql.catalyst.InternalRow

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -537,9 +537,14 @@ case class WholeStageCodegenRDD(@transient sc: SparkContext, var source: CodeAnd
     var cause = e
     while (cause ne null) {
       // Don't log the code when the exception is out of memory
-      if (cause.isInstanceOf[SQLException] &&
-        cause.asInstanceOf[SQLException].getSQLState == "XCL54.T") {
-        return
+      cause match {
+        case e: SQLException if e.getSQLState == "XCL54.T" =>
+          return
+        case o: RuntimeException if o.getClass.equals(
+          // scalastyle:off classforname
+          Class.forName("com.gemstone.gemfire.cache.LowMemoryException")) =>
+          return
+        case _ =>
       }
       cause = cause.getCause
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -540,9 +540,7 @@ case class WholeStageCodegenRDD(@transient sc: SparkContext, var source: CodeAnd
       cause match {
         case e: SQLException if e.getSQLState == "XCL54.T" =>
           return
-        case o: RuntimeException if o.getClass.equals(
-          // scalastyle:off classforname
-          Class.forName("com.gemstone.gemfire.cache.LowMemoryException")) =>
+        case e: RuntimeException if e.getClass.getName.contains("LowMemoryException") =>
           return
         case _ =>
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't log the generated code when a low memory exception is being thrown. Also, fixed a review comment that print a exception message before the generated code

## How was this patch tested?

Manual. Precheckin. 