### PR TITLE
[SNAPPYDATA][AQP-293] Native JNI callback changes for UTF8String

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
@@ -142,5 +142,5 @@ public final class Native {
       long rightAddress, long size);
 
   public static native boolean containsString(long sourceAddress,
-      long sourceEnd, long destAddress, int destSize);
+      int sourceSize, long destAddress, int destSize);
 }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Native.java
@@ -30,13 +30,16 @@ import org.apache.log4j.Logger;
  */
 public final class Native {
 
-  public static final int MIN_JNI_SIZE = 32;
+  public static final int MIN_JNI_SIZE = Integer.getInteger("spark.utf8.jniSize", 32);
 
   public static final boolean debug;
   private static final Logger logger;
 
+  private static boolean isMac;
+  private static boolean isWindows;
+  private static boolean isSolaris;
+
   private static final boolean is64Bit;
-  private static final boolean isSolaris;
   private static final boolean nativeLoaded;
 
   private Native() {
@@ -45,14 +48,25 @@ public final class Native {
   static {
     debug = Boolean.getBoolean("spark.native.debug");
 
+    String suffix = "";
+    String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+    if (os.startsWith("mac") || os.startsWith("darwin")) {
+      isMac = true;
+      // no suffix since library extension will be different
+    } else if (os.startsWith("windows")) {
+      isWindows = true;
+      // no suffix since library extension will be different
+    } else if (os.startsWith("sunos") || os.startsWith("solaris")) {
+      isSolaris = true;
+      suffix = "_sol";
+    }
+
     String arch = System.getProperty("os.arch");
     is64Bit = arch.contains("64") || arch.contains("s390x");
-    String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-    isSolaris = os.contains("sunos") || os.contains("solaris");
 
     logger = Logger.getLogger(Native.class);
 
-    String library = isSolaris() ? "native_sol" : "native";
+    String library = "native" + suffix;
     if (is64Bit()) {
       library += "64";
     }
@@ -105,6 +119,14 @@ public final class Native {
     return is64Bit;
   }
 
+  public static boolean isMac() {
+    return isMac;
+  }
+
+  public static boolean isWindows() {
+    return isWindows;
+  }
+
   public static boolean isSolaris() {
     return isSolaris;
   }
@@ -114,6 +136,9 @@ public final class Native {
   }
 
   public static native boolean arrayEquals(long leftAddress,
+      long rightAddress, long size);
+
+  public static native int compareString(long leftAddress,
       long rightAddress, long size);
 
   public static native boolean containsString(long sourceAddress,

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/array/ByteArrayMethods.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.unsafe.array;
 
-import org.apache.spark.unsafe.Native;
 import org.apache.spark.unsafe.Platform;
 
 public class ByteArrayMethods {
@@ -47,10 +46,14 @@ public class ByteArrayMethods {
    */
   public static boolean arrayEquals(final Object leftBase, long leftOffset,
       final Object rightBase, long rightOffset, final long length) {
+    // for the case that equals will fail in first few bytes itself, the overhead
+    // of JNI call is too high
+    /*
     if (leftBase == null && rightBase == null &&
-        length > Native.MIN_JNI_SIZE && Native.isLoaded()) {
+        length >= Native.MIN_JNI_SIZE && Native.isLoaded()) {
       return Native.arrayEquals(leftOffset, rightOffset, length);
     }
+    */
     long endOffset = leftOffset + length;
     // try to align at least one side
     if ((rightOffset & 0x7) != 0 && (leftOffset & 0x7) != 0) { // mod 8

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -298,7 +298,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     final Object base = this.base;
     final int len = this.numBytes;
     // noinspection ConstantConditions
-    if (base == null && len > Native.MIN_JNI_SIZE &&
+    if (base == null && len >= Native.MIN_JNI_SIZE &&
         substring.base == null && Native.isLoaded()) {
       return Native.containsString(offset, offset + len, substring.offset, slen);
     }
@@ -1073,6 +1073,18 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     long leftOffset = offset;
 
     final int len = Math.min(numBytes, other.numBytes);
+
+    // for the case that compare will fail in first few bytes itself, the overhead
+    // of JNI call is too high
+    /*
+    // noinspection ConstantConditions
+    if (leftBase == null && rightBase == null &&
+        len >= Native.MIN_JNI_SIZE && Native.isLoaded()) {
+      final int result = Native.compareString(leftOffset, rightOffset, len);
+      return result != 0 ? result : (numBytes - other.numBytes);
+    }
+    */
+
     long endOffset = leftOffset + len;
     // for architectures that support unaligned accesses, read 8 bytes at a time
     if (Platform.unaligned() || (((leftOffset & 0x7) == 0) && ((rightOffset & 0x7) == 0))) {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -300,7 +300,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     // noinspection ConstantConditions
     if (base == null && len >= Native.MIN_JNI_SIZE &&
         substring.base == null && Native.isLoaded()) {
-      return Native.containsString(offset, offset + len, substring.offset, slen);
+      return Native.containsString(offset, len, substring.offset, slen);
     }
 
     final byte first = substring.getByte(0);

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -336,7 +336,7 @@ private[spark] class Executor(
             if (conf.getBoolean("spark.unsafe.exceptionOnMemoryLeak", false)) {
               throw new SparkException(errMsg)
             } else {
-              logWarning(errMsg)
+              logDebug(errMsg)
             }
           }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- added MacOSX library handling to Native; made minimum size to use JNI
  as configurable (system property "spark.utf8.jniSize")
- added compareString to Native API for string comparison
- commented out JNI for ByteArrayMethods.arrayEquals since it is seen to be less efficient
  for cases where match fails in first few bytes (JNI overhead of 5-7ns is far more)
- made the "memory leak" warning in Executor to be debug level; reason being that
  it comes from proper MemoryConsumers so its never a leak and it should not be
  required of MemoryConsumers to always clean up memory (unnessary addition task listeners)

## How was this patch tested?

snappydata precheckin