### PR TITLE
[SNAP-2033] pass the original number of buckets in table separately to OrderlessHashPartitioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ subprojects {
   }
   test {
     jvmArgs '-Xss4096k'
-    maxParallelForks = (2 * Runtime.getRuntime().availableProcessors())
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
     systemProperties 'spark.master.rest.enabled': 'false',
       'test.src.tables': 'src'
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -254,7 +254,7 @@ case object SinglePartition extends Partitioning {
  * than this partitioning then also it is considered equal.
  */
 case class OrderlessHashPartitioning(expressions: Seq[Expression],
-    aliases: Seq[Seq[Attribute]], numPartitions: Int, numBuckets: Int)
+    aliases: Seq[Seq[Attribute]], numPartitions: Int, numBuckets: Int, tableBuckets: Int)
     extends Expression with Partitioning with Unevaluable {
 
   override def children: Seq[Expression] = expressions


### PR DESCRIPTION
## What changes were proposed in this pull request?

reduced parallel forks in tests to be same as number of processors/cores

## How was this patch tested?

snappydata precheckin