### PR TITLE
Snap 2084

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -372,15 +372,17 @@ object SparkEnv extends Logging {
 
     val useLegacyMemoryManager = conf.getBoolean("spark.memory.useLegacyMode", false)
     val memoryManager: MemoryManager =
-      conf.getOption("spark.memory.manager").filterNot(_.equalsIgnoreCase("default"))
-          .map(Utils.classForName(_)
-          .getConstructor(classOf[SparkConf], classOf[Int])
-          .newInstance(conf, Int.box(numUsableCores))
-          .asInstanceOf[MemoryManager]).getOrElse {
-        if (useLegacyMemoryManager) {
-          new StaticMemoryManager(conf, numUsableCores)
-        } else {
-          UnifiedMemoryManager(conf, numUsableCores)
+      SparkSnappyUtils.loadSnappyManager(conf, numUsableCores).getOrElse {
+        conf.getOption("spark.memory.manager").filterNot(_.equalsIgnoreCase("default"))
+            .map(Utils.classForName(_)
+                .getConstructor(classOf[SparkConf], classOf[Int])
+                .newInstance(conf, Int.box(numUsableCores))
+                .asInstanceOf[MemoryManager]).getOrElse {
+          if (useLegacyMemoryManager) {
+            new StaticMemoryManager(conf, numUsableCores)
+          } else {
+            UnifiedMemoryManager(conf, numUsableCores)
+          }
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -372,12 +372,12 @@ object SparkEnv extends Logging {
 
     val useLegacyMemoryManager = conf.getBoolean("spark.memory.useLegacyMode", false)
     val memoryManager: MemoryManager =
-      SparkSnappyUtils.loadSnappyManager(conf, numUsableCores).getOrElse {
-        conf.getOption("spark.memory.manager").filterNot(_.equalsIgnoreCase("default"))
-            .map(Utils.classForName(_)
-                .getConstructor(classOf[SparkConf], classOf[Int])
-                .newInstance(conf, Int.box(numUsableCores))
-                .asInstanceOf[MemoryManager]).getOrElse {
+      conf.getOption("spark.memory.manager").filterNot(_.equalsIgnoreCase("default"))
+          .map(Utils.classForName(_)
+              .getConstructor(classOf[SparkConf], classOf[Int])
+              .newInstance(conf, Int.box(numUsableCores))
+              .asInstanceOf[MemoryManager]).getOrElse {
+        SparkSnappyUtils.loadSnappyManager(conf, numUsableCores).getOrElse {
           if (useLegacyMemoryManager) {
             new StaticMemoryManager(conf, numUsableCores)
           } else {

--- a/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 /*
- * Changes for SnappyData data platform.
- *
- * Portions Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You

--- a/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
@@ -1,5 +1,23 @@
 /*
- * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017 SnappyData, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -8,12 +26,13 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS  IS" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  * implied. See the License for the specific language governing
  * permissions and limitations under the License. See accompanying
  * LICENSE file.
  */
+
 package org.apache.spark
 
 import org.apache.spark.memory.MemoryManager

--- a/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 SnappyData, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS  IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark
+
+import org.apache.spark.memory.MemoryManager
+import org.apache.spark.util.Utils
+
+
+object SparkSnappyUtils {
+
+  val SNAPPY_UNIFIED_MEMORY_MANAGER_CLASS = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
+
+  def loadSnappyManager(conf: SparkConf, numUsableCores: Int): Option[MemoryManager] = {
+    try {
+      Some(Utils.classForName(SNAPPY_UNIFIED_MEMORY_MANAGER_CLASS)
+          .getConstructor(classOf[SparkConf], classOf[Int])
+          .newInstance(conf, Int.box(numUsableCores))
+          .asInstanceOf[MemoryManager])
+    } catch {
+      case ex: ClassNotFoundException => None
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
The PR changes the way Snappy UMM is set to the cluster. If SnappyUMM is found in classpath , SparkEnv will assign the memory manager to SnappyUMM
## How was this patch tested?
pre-checkin (Pending),  manual tests

