### PR TITLE
[SNAP-2120] make codegen cache size configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1684,6 +1684,7 @@ class SparkContext(config: SparkConf) extends Logging {
   @DeveloperApi
   def getAllPools: Seq[Schedulable] = {
     assertNotStopped()
+    if (taskScheduler eq null) return Seq.empty
     // TODO(xiajunluan): We should take nested pools into account
     taskScheduler.rootPool.schedulableQueue.asScala.toSeq
   }

--- a/core/src/main/scala/org/apache/spark/memory/MemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/MemoryPool.scala
@@ -36,14 +36,14 @@ private[memory] abstract class MemoryPool(lock: Object) {
    * Returns the current size of the pool, in bytes.
    */
   final def poolSize: Long = lock.synchronized {
-    _poolSize
+    return _poolSize
   }
 
   /**
    * Returns the amount of free memory in the pool, in bytes.
    */
   final def memoryFree: Long = lock.synchronized {
-    _poolSize - memoryUsed
+    return _poolSize - memoryUsed
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1019,9 +1019,12 @@ object CodeGenerator extends Logging {
    * automatically, in order to constrain its memory footprint.  Note that this cache does not use
    * weak keys/values and thus does not respond to memory pressure.
    */
-  private val cache = CacheBuilder.newBuilder()
-    .maximumSize(300)
-    .build(
+  private lazy val cache = {
+    val env = SparkEnv.get
+    val cacheSize = if (env ne null) {
+      env.conf.getInt("spark.sql.codegen.cacheSize", 1000)
+    } else 1000
+    CacheBuilder.newBuilder().maximumSize(cacheSize).build(
       new CacheLoader[CodeAndComment, GeneratedClass]() {
         override def load(code: CodeAndComment): GeneratedClass = {
           val startTime = System.nanoTime()
@@ -1034,4 +1037,5 @@ object CodeGenerator extends Logging {
           result
         }
       })
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- use "spark.sql.codegen.cacheSize" to set codegenerator cache size else default to 1000
- also added explicit returns in MemoryPool else it does boxing/unboxing inside
  the sync block that also shows up in perf analysis (can be seen via decompiler too)

## How was this patch tested?

manually confirmed that cache size is getting increased on servers/lead on setting the property
on lead