### PR TITLE
[SNAP-2218] honour timeout in netty RPC transfers

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
@@ -150,6 +150,16 @@ private[spark] abstract class RpcEnv(conf: SparkConf) {
    * @param uri URI with location of the file.
    */
   def openChannel(uri: String): ReadableByteChannel
+
+  /**
+   * Open a channel to download a file from the given URI. If the URIs returned by the
+   * RpcEnvFileServer use the "spark" scheme, this method will be called by the Utils class to
+   * retrieve the files.
+   *
+   * @param uri URI with location of the file.
+   * @param readTimeoutMs timeout in reading in millisecond
+   */
+  def openChannel(uri: String, readTimeoutMs: Long): ReadableByteChannel
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -344,7 +344,7 @@ private[netty] class NettyRpcEnv(
 
   override def openChannel(uri: String, readTimeoutMs: Long): ReadableByteChannel = {
     val source = openChannel(uri)
-    if (readTimeoutMs > 0L) {
+    if (readTimeoutMs > 0) {
       source.asInstanceOf[FileDownloadChannel].setTimeoutMs(readTimeoutMs)
     }
     source
@@ -390,7 +390,7 @@ private[netty] class NettyRpcEnv(
 
     override def read(dst: ByteBuffer): Int = {
       def readBuffer: Int = if (timeoutMs > 0) {
-        implicit val context = ExecutionContext.fromExecutorService(clientConnectionExecutor)
+        val context = ExecutionContext.fromExecutorService(clientConnectionExecutor)
         val future = Future(source.read(dst))(context)
         ThreadUtils.awaitResult(future, Duration(timeoutMs, TimeUnit.MILLISECONDS))
       } else source.read(dst)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -347,6 +347,7 @@ private[netty] class NettyRpcEnv(
     if (readTimeoutMs > 0L) {
       source.asInstanceOf[FileDownloadChannel].setTimeoutMs(readTimeoutMs)
     }
+    source
   }
 
   private def downloadClient(host: String, port: Int): TransportClient = {

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -24,8 +24,8 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.Nullable
 
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag
 import scala.util.{DynamicVariable, Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -392,7 +392,7 @@ private[netty] class NettyRpcEnv(
       val readBuffer = if (timeoutMs > 0) {
         implicit val context = ExecutionContext.fromExecutorService(clientConnectionExecutor)
         val future = Future(source.read(dst))(context)
-        Await.result(future, Duration(timeoutMs, TimeUnit.MILLISECONDS))
+        ThreadUtils.awaitResult(future, Duration(timeoutMs, TimeUnit.MILLISECONDS))
       } else source.read(dst)
       Try(readBuffer) match {
         case Success(bytesRead) => bytesRead

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -389,7 +389,7 @@ private[netty] class NettyRpcEnv(
     }
 
     override def read(dst: ByteBuffer): Int = {
-      val readBuffer = if (timeoutMs > 0) {
+      def readBuffer: Int = if (timeoutMs > 0) {
         implicit val context = ExecutionContext.fromExecutorService(clientConnectionExecutor)
         val future = Future(source.read(dst))(context)
         ThreadUtils.awaitResult(future, Duration(timeoutMs, TimeUnit.MILLISECONDS))

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -695,7 +695,9 @@ private[spark] object Utils extends Logging {
           throw new IllegalStateException(
             "Cannot retrieve files with 'spark' scheme without an active SparkEnv.")
         }
-        val source = SparkEnv.get.rpcEnv.openChannel(url)
+        // wait for max double the configured time (connect + read time)
+        val timeoutMs = conf.getTimeAsSeconds("spark.files.fetchTimeout", "60s") * 2000L
+        val source = SparkEnv.get.rpcEnv.openChannel(url, timeoutMs)
         val is = Channels.newInputStream(source)
         downloadFile(url, is, targetFile, fileOverwrite)
       case "http" | "https" | "ftp" =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

use a future for enforcing timeout (2 x configured value) in netty RPC transfers
after which the channel will be closed and fail

## How was this patch tested?

snappydata precheckin with spark test suite run