### PR TITLE
[SNAP-2225] Removed OrderlessHashPartitioning.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -255,12 +255,6 @@ case object SinglePartition extends Partitioning {
 case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
     extends Expression with Partitioning with Unevaluable {
 
-  private[sql] var buckets: Int = 0
-
-  def numBuckets(): Int = {
-    buckets
-  }
-
   override def children: Seq[Expression] = expressions
   override def nullable: Boolean = false
   override def dataType: DataType = IntegerType
@@ -273,14 +267,12 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
   }
 
   override def compatibleWith(other: Partitioning): Boolean = other match {
-    case o: HashPartitioning =>
-      this.numBuckets == o.numBuckets && this.semanticEquals(o)
+    case o: HashPartitioning => this.semanticEquals(o)
     case _ => false
   }
 
   override def guarantees(other: Partitioning): Boolean = other match {
-    case o: HashPartitioning =>
-      this.numBuckets == o.numBuckets && this.semanticEquals(o)
+    case o: HashPartitioning => this.semanticEquals(o)
     case _ => false
   }
 
@@ -289,16 +281,6 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
    * than numPartitions) based on hashing expressions.
    */
   def partitionIdExpression: Expression = Pmod(new Murmur3Hash(expressions), Literal(numPartitions))
-}
-
-object HashPartitioning {
-
-  def apply(expressions: Seq[Expression], numPartitions: Int,
-      numBuckets: Int): HashPartitioning = {
-    val partitioning = HashPartitioning(expressions, numPartitions)
-    partitioning.buckets = numBuckets
-    partitioning
-  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -255,7 +255,11 @@ case object SinglePartition extends Partitioning {
 case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
     extends Expression with Partitioning with Unevaluable {
 
-  private[sql] var numBuckets: Int = 0
+  private[sql] var buckets: Int = 0
+
+  def numBuckets(): Int = {
+    buckets
+  }
 
   override def children: Seq[Expression] = expressions
   override def nullable: Boolean = false
@@ -292,7 +296,7 @@ object HashPartitioning {
   def apply(expressions: Seq[Expression], numPartitions: Int,
       numBuckets: Int): HashPartitioning = {
     val partitioning = HashPartitioning(expressions, numPartitions)
-    partitioning.numBuckets = numBuckets
+    partitioning.buckets = numBuckets
     partitioning
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -250,53 +250,6 @@ case object SinglePartition extends Partitioning {
 /**
  * Represents a partitioning where rows are split up across partitions based on the hash
  * of `expressions`.  All rows where `expressions` evaluate to the same values are guaranteed to be
- * in the same partition. Moreover while evaluating expressions if they are given in different order
- * than this partitioning then also it is considered equal.
- */
-case class OrderlessHashPartitioning(expressions: Seq[Expression],
-    aliases: Seq[Seq[Attribute]], numPartitions: Int, numBuckets: Int, tableBuckets: Int)
-    extends Expression with Partitioning with Unevaluable {
-
-  override def children: Seq[Expression] = expressions
-  override def nullable: Boolean = false
-  override def dataType: DataType = IntegerType
-
-  private def matchExpressions(otherExpression: Seq[Expression]): Boolean = {
-    expressions.length == otherExpression.length &&
-        expressions.zipWithIndex.forall { case (a, i) =>
-          otherExpression.exists(e => e.semanticEquals(a) ||
-              (aliases.nonEmpty && aliases(i).exists(a2 => e.semanticEquals(a2))))
-        }
-  }
-
-  override def satisfies(required: Distribution): Boolean = required match {
-    case UnspecifiedDistribution => true
-    case ClusteredDistribution(requiredClustering) =>
-      matchExpressions(requiredClustering)
-    case _ => false
-  }
-
-  private def anyOrderEquals(other: HashPartitioning) : Boolean = {
-    other.numBuckets == this.numBuckets &&
-    other.numPartitions == this.numPartitions &&
-        matchExpressions(other.expressions)
-  }
-
-  override def compatibleWith(other: Partitioning): Boolean = other match {
-    case p: HashPartitioning => anyOrderEquals(p)
-    case _ => false
-  }
-
-  override def guarantees(other: Partitioning): Boolean = other match {
-    case p: HashPartitioning => anyOrderEquals(p)
-    case _ => false
-  }
-
-}
-
-/**
- * Represents a partitioning where rows are split up across partitions based on the hash
- * of `expressions`.  All rows where `expressions` evaluate to the same values are guaranteed to be
  * in the same partition.
  */
 case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -47,11 +47,11 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
    */
   private def createPartitioning(
       requiredDistribution: Distribution,
-      numPartitions: Int, numBuckets: Int = 0): Partitioning = {
+      numPartitions: Int): Partitioning = {
     requiredDistribution match {
       case AllTuples => SinglePartition
       case ClusteredDistribution(clustering) =>
-        HashPartitioning(clustering, numPartitions, numBuckets)
+        HashPartitioning(clustering, numPartitions)
       case OrderedDistribution(ordering) => RangePartitioning(ordering, numPartitions)
       case dist => sys.error(s"Do not know how to satisfy distribution $dist")
     }
@@ -188,14 +188,11 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         case (child, false) => child.outputPartitioning.numPartitions
         case (child, true) => -child.outputPartitioning.numPartitions
       }.max)
-      val numBuckets = children.map(_.outputPartitioning match {
-        case p: OrderlessHashPartitioning => p.numBuckets
-        case _ => 0
-      }).max
+
       val useExistingPartitioning = children.zip(requiredChildDistributions).forall {
         case (child, distribution) =>
           child.outputPartitioning.guarantees(
-            createPartitioning(distribution, maxChildrenNumPartitions, numBuckets))
+            createPartitioning(distribution, maxChildrenNumPartitions))
       }
 
       children = if (useExistingPartitioning) {


### PR DESCRIPTION
Handled join order in optimization phase.


## What changes were proposed in this pull request?
Also removed custom changes in HashPartition. We won't store bucket information in HashPartitioning. Instead based on the flag "linkPartitionToBucket" we can determine the number of partitions to be either numBuckets or num cores assigned to the executor. 

Reverted changes related to numBuckets in Snappy Spark.

## How was this patch tested?

pre-checkin, manual tests

Please review http://spark.apache.org/contributing.html before opening a pull request.
