### PR TITLE
[SNAP-2242] Unique application names & kill app by names

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -50,7 +50,6 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") with Log
   }
 
   def handleAppStopRequest(request: HttpServletRequest): Unit = {
-    logInfo(" Got stop request")
     handleStopRequest(request, name => {
       parent.master.nameToApp.get(name.toLowerCase).foreach { app =>
         parent.master.removeApplication(app, ApplicationState.KILLED)
@@ -82,7 +81,6 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") with Log
         parent.master.securityMgr.checkModifyPermissions(request.getRemoteUser)) {
       val name = Option(request.getParameter("name"))
       if (name.isDefined) {
-        logInfo(" Got stop request "+name.get)
         action(name.get)
       }
       Thread.sleep(100)

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
@@ -51,6 +51,8 @@ class MasterWebUI(
     attachHandler(createRedirectHandler(
       "/app/kill", "/", masterPage.handleAppKillRequest, httpMethods = Set("POST")))
     attachHandler(createRedirectHandler(
+      "/app/stop", "/", masterPage.handleAppStopRequest, httpMethods = Set("POST")))
+    attachHandler(createRedirectHandler(
       "/driver/kill", "/", masterPage.handleDriverKillRequest, httpMethods = Set("POST")))
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
@@ -51,7 +51,7 @@ class MasterWebUI(
     attachHandler(createRedirectHandler(
       "/app/kill", "/", masterPage.handleAppKillRequest, httpMethods = Set("POST")))
     attachHandler(createRedirectHandler(
-      "/app/stop", "/", masterPage.handleAppStopRequest, httpMethods = Set("POST")))
+      "/app/killByName", "/", masterPage.handleAppKillByNameRequest, httpMethods = Set("POST")))
     attachHandler(createRedirectHandler(
       "/driver/kill", "/", masterPage.handleDriverKillRequest, httpMethods = Set("POST")))
   }

--- a/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
@@ -74,7 +74,7 @@ class MasterWebUISuite extends SparkFunSuite with BeforeAndAfterAll {
     verify(master, times(1)).removeApplication(activeApp, ApplicationState.KILLED)
   }
 
-  test("Stop application") {
+  test("Kill application by name") {
     val appDesc = createAppDesc()
     // use new start date so it isn't filtered by UI
     val activeApp = new ApplicationInfo(
@@ -83,8 +83,8 @@ class MasterWebUISuite extends SparkFunSuite with BeforeAndAfterAll {
     when(master.nameToApp).thenReturn(HashMap[String,
         ApplicationInfo]((activeApp.desc.name, activeApp)))
 
-    val url = s"http://localhost:${masterWebUI.boundPort}/app/stop/"
-    val body = convPostDataToString(Map(("name", activeApp.desc.name)))
+    val url = s"http://localhost:${masterWebUI.boundPort}/app/killByName/"
+    val body = convPostDataToString(Map(("name", activeApp.desc.name), ("terminate", "true")))
     val conn = sendHttpRequest(url, "POST", body)
     conn.getResponseCode
 

--- a/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/ui/MasterWebUISuite.scala
@@ -74,6 +74,24 @@ class MasterWebUISuite extends SparkFunSuite with BeforeAndAfterAll {
     verify(master, times(1)).removeApplication(activeApp, ApplicationState.KILLED)
   }
 
+  test("Stop application") {
+    val appDesc = createAppDesc()
+    // use new start date so it isn't filtered by UI
+    val activeApp = new ApplicationInfo(
+      new Date().getTime, "app-0", appDesc, new Date(), null, Int.MaxValue)
+
+    when(master.nameToApp).thenReturn(HashMap[String,
+        ApplicationInfo]((activeApp.desc.name, activeApp)))
+
+    val url = s"http://localhost:${masterWebUI.boundPort}/app/stop/"
+    val body = convPostDataToString(Map(("name", activeApp.desc.name)))
+    val conn = sendHttpRequest(url, "POST", body)
+    conn.getResponseCode
+
+    // Verify the master was called to remove the active app
+    verify(master, times(1)).removeApplication(activeApp, ApplicationState.KILLED)
+  }
+
   test("kill driver") {
     val activeDriverId = "driver-0"
     val url = s"http://localhost:${masterWebUI.boundPort}/driver/kill/"


### PR DESCRIPTION
## What changes were proposed in this pull request?
The standalone cluster should support unique application names. As they are user visible and easy to track user can write scripts to kill applications by names.
Also, I have added support to kill Spark applications by names(case insensitive).

## How was this patch tested?

Manual & precheckin


