### PR TITLE
[SNAP-2379] App was getting registered with error

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -240,15 +240,17 @@ private[deploy] class Master(
         logInfo("Registering app " + description.name)
         val app = createApplication(description, driver)
         if (nameToApp.get(app.desc.name.toLowerCase).isDefined) {
-          val msg = s"An application with name ${app.desc.name} is already running"
+          val msg = s"An application with name ${app.desc.name} is already running" +
+              s" with app id ${app.id}"
           logError(msg)
           driver.send(ApplicationRemoved(msg))
+        } else {
+          registerApplication(app)
+          logInfo("Registered app " + description.name + " with ID " + app.id)
+          persistenceEngine.addApplication(app)
+          driver.send(RegisteredApplication(app.id, self))
+          schedule()
         }
-        registerApplication(app)
-        logInfo("Registered app " + description.name + " with ID " + app.id)
-        persistenceEngine.addApplication(app)
-        driver.send(RegisteredApplication(app.id, self))
-        schedule()
       }
 
     case ExecutorStateChanged(appId, execId, state, message, exitStatus) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change pertains to the modification to Standalone cluster for not allowing applications with the same name. 
The change was erroneous and was allowing the app to get registered even after determining a duplicate name.  

## How was this patch tested?

Manual tests with duplicate app names.
pre check in pending. 

Please review http://spark.apache.org/contributing.html before opening a pull request.
