### PR TITLE
Fix to SNAP-2247

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -434,13 +434,13 @@ object CatalystTypeConverters {
     case d: BigDecimal =>
       var precision = d.precision
       if (d.precision < d.scale) {
-        precision = d.scale
+        precision = d.scale + 1
       }
       new DecimalConverter(DecimalType(precision, d.scale)).toCatalyst(d)
     case d: JavaBigDecimal =>
       var precision = d.precision
       if (d.precision < d.scale) {
-        precision = d.scale
+        precision = d.scale + 1
       }
       new DecimalConverter(DecimalType(precision, d.scale)).toCatalyst(d)
     case seq: Seq[Any] => new GenericArrayData(seq.map(convertToCatalyst).toArray)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -431,8 +431,18 @@ object CatalystTypeConverters {
     case s: String => StringConverter.toCatalyst(s)
     case d: Date => DateConverter.toCatalyst(d)
     case t: Timestamp => TimestampConverter.toCatalyst(t)
-    case d: BigDecimal => new DecimalConverter(DecimalType(d.precision, d.scale)).toCatalyst(d)
-    case d: JavaBigDecimal => new DecimalConverter(DecimalType(d.precision, d.scale)).toCatalyst(d)
+    case d: BigDecimal =>
+      var precision = d.precision
+      if (d.precision < d.scale) {
+        precision = d.scale
+      }
+      new DecimalConverter(DecimalType(precision, d.scale)).toCatalyst(d)
+    case d: JavaBigDecimal =>
+      var precision = d.precision
+      if (d.precision < d.scale) {
+        precision = d.scale
+      }
+      new DecimalConverter(DecimalType(precision, d.scale)).toCatalyst(d)
     case seq: Seq[Any] => new GenericArrayData(seq.map(convertToCatalyst).toArray)
     case r: Row => InternalRow(r.toSeq.map(convertToCatalyst): _*)
     case arr: Array[Any] => new GenericArrayData(arr.map(convertToCatalyst))


### PR DESCRIPTION
This is related to a bug in Spark as to how it handles decimal values where precision is less than scale. Please see PR https://github.com/apache/spark/pull/17529

## What changes were proposed in this pull request?

Needed to do similar change in the code path of prepared statement
where precision needed to be adjusted if smaller than scale.

## How was this patch tested?
A unit test in cluster was added.
