### PR TITLE
SNAP-2377: Trend charts layout in dashboard UI seems disturbed in google chrome on latest master.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.css
@@ -192,7 +192,8 @@
 }
 
 .graph-container {
-  width: 400px;
+  min-width: 250px;
+  width: 20%;
   height: 200px;
   display: inline-block;
   margin: 10px;


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem:** 
    Trend charts layout in dashboard UI seems disturbed in google chrome on latest master

**Fixes:**
  - Changing fixed width to width in percent for all trends charts on UI.
(Please fill in changes proposed in this fix)

## How was this patch tested?

 - Tested manually on different web browsers and with different screen resolutions.
