### PR TITLE
SNAP-2787: Add option "ALL" in show entries dropdown list of tabular lists

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
@@ -182,6 +182,7 @@ function getMemberStatsGridConf() {
   // Members Grid Data Table Configurations
   var memberStatsGridConf = {
     data: memberStatsGridData,
+    "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     "columns": [
       { // Status
         data: function(row, type) {
@@ -262,6 +263,7 @@ function getTableStatsGridConf() {
   // Tables Grid Data Table Configurations
   var tableStatsGridConf = {
     data: tableStatsGridData,
+    "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     "columns": [
       { // Name
         data: function(row, type) {
@@ -340,6 +342,7 @@ function getExternalTableStatsGridConf() {
   // External Tables Grid Data Table Configurations
   var extTableStatsGridConf = {
     data: extTableStatsGridData,
+    "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     "columns": [
       { // Name
         data: function(row, type) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Description:
 - Now _Show Entries_ drop down contains an option _"ALL"_, so that user can see all the entries present in the tabular lists without pagination.

Changes:
 - Adding an option "ALL" in show entries dropdown list of tabular lists, in order to display all the table entries to avoid paging, if user needs.

## How was this patch tested?

 - Tested manually.

Please review http://spark.apache.org/contributing.html before opening a pull request.
