### PR TITLE
SNAP-2611 : Sort the tables and external tables on the name by default.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
@@ -324,6 +324,7 @@ function getTableStatsGridConf() {
               }
       }
     ],
+    "order": [[0, 'asc']],
     columnDefs: [
       { type: 'file-size', targets: 4 },
       { type: 'file-size', targets: 5 },
@@ -364,7 +365,8 @@ function getExternalTableStatsGridConf() {
                 return sourceHtml;
               }
       }
-    ]
+    ],
+    "order": [[0, 'asc']]
   }
 
   return extTableStatsGridConf;


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - Adding configuration parameter for setting ordering column.

## How was this patch tested?

 - Tested manually

Please review http://spark.apache.org/contributing.html before opening a pull request.
