### PR TITLE
SNAP-2926: Suggestions for tabular lists on Dashboard

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
@@ -183,6 +183,7 @@ function getMemberStatsGridConf() {
   var memberStatsGridConf = {
     data: memberStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    "iDisplayLength": 50,
     "columns": [
       { // Status
         data: function(row, type) {
@@ -253,7 +254,8 @@ function getMemberStatsGridConf() {
               },
         "orderable": false
       }
-    ]
+    ],
+    "order": [[2, 'desc']]
   }
 
   return memberStatsGridConf;
@@ -264,6 +266,7 @@ function getTableStatsGridConf() {
   var tableStatsGridConf = {
     data: tableStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    "iDisplayLength": 50,
     "columns": [
       { // Name
         data: function(row, type) {
@@ -340,6 +343,7 @@ function getExternalTableStatsGridConf() {
   var extTableStatsGridConf = {
     data: extTableStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+    "iDisplayLength": 50,
     "columns": [
       { // Name
         data: function(row, type) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Requirements:**
  - Sorting Members 'Type' 
    i.e. by default show all data servers together. 
    Maybe, by default, show
    - Locator(s)
    - Lead(s)
    - All data servers
  - Change the default list sizes from 10 to 50?

**Changes:**
  - Changing default page size for all tabular lists from  10 to 50.
  - Sorting Members List tabular view on Member Type for ordering all nodes such that
   all locators first, then all leads and then servers.


## How was this patch tested?

 - Tested Manually

Please review http://spark.apache.org/contributing.html before opening a pull request.
