### PR TITLE
[SNAP-2934] Avoid double free of page that caused server crash due to SIGABORT/SIGSEGV

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorter.java
@@ -162,7 +162,7 @@ public final class UnsafeInMemorySorter {
    * Free the memory used by pointer array.
    */
   public void free() {
-    if (consumer != null) {
+    if (consumer != null && array != null) {
       consumer.freeArray(array);
       array = null;
     }
@@ -171,6 +171,7 @@ public final class UnsafeInMemorySorter {
   public void reset() {
     if (consumer != null) {
       consumer.freeArray(array);
+      array = null;
       array = consumer.allocateArray(initialSize);
       usableCapacity = getUsableCapacity();
     }
@@ -193,7 +194,7 @@ public final class UnsafeInMemorySorter {
   }
 
   public long getMemoryUsage() {
-    return array.size() * 8;
+    return (array == null) ? 0 : array.size() * 8;
   }
 
   public boolean hasSpaceForAnotherRecord() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The fix avoids double free of array by setting it to null when freed. 

Root cause:-

UnsafeExternalSorter#spill() resets the  UnsafeInMemorySorter there by freeing its UnsafeInMemorySorter#array  (line 173 in the code snippet below)

UnsafeInMemorySorter.java:-
```
171   public void reset() {
172     if (consumer != null) {
173       consumer.freeArray(array);
174       array = consumer.allocateArray(initialSize);
175       usableCapacity = getUsableCapacity();
176     }
```
However if the call to `consumer.allocateArray()`  on the subsequent line, fails due to Spark layer OOM exception, then this `array`  now points freed memory block.  The task fails and the TaskCompletionListener in `org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter`  tries to free up all resources by a call to `UnsafeExternalSorter#cleanupResources`   which again tries to free up the same array causing SIGABORT/SIGSEGV. Refer the code below-

UnsafeExternalSorter#cleanupResources 

```
333   public void cleanupResources() {
334     synchronized (this) {
335       deleteSpillFiles();
336       freeMemory();
337       if (inMemSorter != null) {
338         inMemSorter.free();
339         inMemSorter = null;
340       }
341     }
```
Notice the call above for  ` inMemSorter.free()` (line 338) and its function body below (line 166)-

```
164   public void free() {
165     if (consumer != null) {
166       consumer.freeArray(array);
167       array = null;
168     }
169   }
```


## How was this patch tested?
Swati has been running the stability tests with this fix. Ran precheckin
