### PR TITLE
Wrap non fatal OOME from Spark layer in a LowMemoryException

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -473,9 +473,24 @@ private[spark] class Executor(
 
           val accUpdates = accums.map(acc => acc.toInfo(Some(acc.value), None))
 
+          // wrap the OOM error in LowMemoryException if
+          // it is a non fatal OOM error thrown from Spark layer
+          val ex: Throwable = t match {
+            case oom: OutOfMemoryError if !isFatalError(t) =>
+              try {
+                val clazz = Utils.classForName("com.gemstone.gemfire.cache.LowMemoryException")
+                val e = clazz.getConstructor(classOf[java.lang.Throwable]).newInstance(t)
+                e.asInstanceOf[Throwable]
+              } catch {
+                // return OOM error as it is if LowMemoryException class is not found
+                case _: ClassNotFoundException => t
+              }
+            case _ => t
+          }
+
           val serializedTaskEndReason = {
             try {
-              ser.serialize(new ExceptionFailure(t, accUpdates).withAccums(accums))
+              ser.serialize(new ExceptionFailure(ex, accUpdates).withAccums(accums))
             } catch {
               case _: NotSerializableException =>
                 // t is not serializable so just send the stacktrace


### PR DESCRIPTION
## What changes were proposed in this pull request?
Wrap non fatal OOME from Spark layer in a LowMemoryException

## How was this patch tested?
- Added a unit test (refer PR https://github.com/SnappyDataInc/snappydata/pull/1277)
- precheckin



Please review http://spark.apache.org/contributing.html before opening a pull request.
