### PR TITLE
Set default value of spark.sql.files.maxPartitionBytes parameter to 32mb

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -478,7 +478,9 @@ object SQLConf {
   val FILES_MAX_PARTITION_BYTES = SQLConfigBuilder("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files.")
     .longConf
-    .createWithDefault(32 * 1024 * 1024) // parquet.block.size
+    // [SnappyData change] set default to 32mb
+    // .createWithDefault(128 * 1024 * 1024) // parquet.block.size
+    .createWithDefault(32 * 1024 * 1024)
 
   val FILES_OPEN_COST_IN_BYTES = SQLConfigBuilder("spark.sql.files.openCostInBytes")
     .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -478,7 +478,7 @@ object SQLConf {
   val FILES_MAX_PARTITION_BYTES = SQLConfigBuilder("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files.")
     .longConf
-    .createWithDefault(128 * 1024 * 1024) // parquet.block.size
+    .createWithDefault(32 * 1024 * 1024) // parquet.block.size
 
   val FILES_OPEN_COST_IN_BYTES = SQLConfigBuilder("spark.sql.files.openCostInBytes")
     .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set default value of spark.sql.files.maxPartitionBytes parameter to 32mb as per the results of stability tests. User can change the value if required.

## How was this patch tested?
- Swati/Sonal have tested this with data ingestion using parquet, csv and ORC format
- precheckin