### PR TITLE
Considering jobserver class loader as a key for generated code cache -

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -909,15 +909,17 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
 }
 
 object CodeGenerator extends Logging {
+  val jobClassLoader = new ThreadLocal[ClassLoader]
+
   /**
    * Compile the Java source code into a Java class, using Janino.
    */
   def compile(code: CodeAndComment): GeneratedClass = {
-    cache.get(code)
+    cache.get((code, jobClassLoader.get()))
   }
 
   def invalidate(code: CodeAndComment) : Unit = {
-    cache.invalidate(code)
+    cache.invalidate((code, jobClassLoader.get()))
   }
 
   /**
@@ -1025,13 +1027,13 @@ object CodeGenerator extends Logging {
       env.conf.getInt("spark.sql.codegen.cacheSize", 2000)
     } else 2000
     CacheBuilder.newBuilder().maximumSize(cacheSize).build(
-      new CacheLoader[CodeAndComment, GeneratedClass]() {
-        override def load(code: CodeAndComment): GeneratedClass = {
+      new CacheLoader[(CodeAndComment, ClassLoader), GeneratedClass]() {
+        override def load(codeAndJobId: (CodeAndComment, ClassLoader)): GeneratedClass = {
           val startTime = System.nanoTime()
-          val result = doCompile(code)
+          val result = doCompile(codeAndJobId._1)
           val endTime = System.nanoTime()
           def timeMs: Double = (endTime - startTime).toDouble / 1000000
-          CodegenMetrics.METRIC_SOURCE_CODE_SIZE.update(code.body.length)
+          CodegenMetrics.METRIC_SOURCE_CODE_SIZE.update(codeAndJobId._1.body.length)
           CodegenMetrics.METRIC_COMPILATION_TIME.update(timeMs.toLong)
           logInfo(s"Code generated in $timeMs ms")
           result

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -909,17 +909,16 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
 }
 
 object CodeGenerator extends Logging {
-  val jobClassLoader = new ThreadLocal[ClassLoader]
 
   /**
    * Compile the Java source code into a Java class, using Janino.
    */
   def compile(code: CodeAndComment): GeneratedClass = {
-    cache.get((code, jobClassLoader.get()))
+    cache.get((code, Thread.currentThread().getContextClassLoader))
   }
 
   def invalidate(code: CodeAndComment) : Unit = {
-    cache.invalidate((code, jobClassLoader.get()))
+    cache.invalidate((code,  Thread.currentThread().getContextClassLoader))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -909,16 +909,17 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
 }
 
 object CodeGenerator extends Logging {
+  val jobClassLoader = new ThreadLocal[ClassLoader]
 
   /**
    * Compile the Java source code into a Java class, using Janino.
    */
   def compile(code: CodeAndComment): GeneratedClass = {
-    cache.get((code, Thread.currentThread().getContextClassLoader))
+    cache.get((code, jobClassLoader.get()))
   }
 
   def invalidate(code: CodeAndComment) : Unit = {
-    cache.invalidate((code,  Thread.currentThread().getContextClassLoader))
+    cache.invalidate((code, jobClassLoader.get()))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1028,12 +1028,12 @@ object CodeGenerator extends Logging {
     } else 2000
     CacheBuilder.newBuilder().maximumSize(cacheSize).build(
       new CacheLoader[(CodeAndComment, ClassLoader), GeneratedClass]() {
-        override def load(codeAndJobId: (CodeAndComment, ClassLoader)): GeneratedClass = {
+        override def load(codeAndClassLoader: (CodeAndComment, ClassLoader)): GeneratedClass = {
           val startTime = System.nanoTime()
-          val result = doCompile(codeAndJobId._1)
+          val result = doCompile(codeAndClassLoader._1)
           val endTime = System.nanoTime()
           def timeMs: Double = (endTime - startTime).toDouble / 1000000
-          CodegenMetrics.METRIC_SOURCE_CODE_SIZE.update(codeAndJobId._1.body.length)
+          CodegenMetrics.METRIC_SOURCE_CODE_SIZE.update(codeAndClassLoader._1.body.length)
           CodegenMetrics.METRIC_COMPILATION_TIME.update(timeMs.toLong)
           logInfo(s"Code generated in $timeMs ms")
           result


### PR DESCRIPTION
## What changes were proposed in this pull request?

Considering jobserver class loader as a key for generated code cache: 

For each submission of a snappy-job, a new URI class loader is used.
The first run of a snappy-job may generate some code and it will cached.
The subsequent run of the snappy job will end up using the generated
code which was cached by the first run of the job. This can lead to
issues as the class loader used for the cached code is the one from the
first job submission and subsequent submissions will be using a
different class loader. This change is done to avoid such failures.

## How was this patch tested?

precheckin with -Pspark

## Other PRs

https://github.com/SnappyDataInc/snappydata/pull/1335
