### PR TITLE
SNAP-3054: Rename UI tab "JDBC/ODBC Server" to "Hive Thrift Server"

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -30,7 +30,7 @@ import org.apache.spark.ui.{SparkUI, SparkUITab}
 private[thriftserver] class ThriftServerTab(sparkContext: SparkContext)
   extends SparkUITab(getSparkUI(sparkContext), "sqlserver") with Logging {
 
-  override val name = "JDBC/ODBC Server"
+  override val name = "Hive Thrift Server"
 
   val parent = getSparkUI(sparkContext)
   val listener = HiveThriftServer2.listener


### PR DESCRIPTION

## What changes were proposed in this pull request?

 - Renaming UI tab name "JDBC/ODBC Server" to "Hive Thrift Server".

## How was this patch tested?

 - Tested Manually

Please review http://spark.apache.org/contributing.html before opening a pull request.
