### PR TITLE
SNAP-3015: Put thousands separators for Tables > Rows Count column in Dashboard.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
@@ -383,7 +383,7 @@ function getTableStatsGridConf() {
       { // Row Count
         data: function(row, type) {
                 var rcHtml = '<div style="padding-right:10px; text-align:right;">'
-                             + row.rowCount
+                             + row.rowCount.toLocaleString(navigator.language)
                            + '</div>';
                 return rcHtml;
               }


### PR DESCRIPTION

## What changes were proposed in this pull request?

 - Adding thousands separators for table row count as per locale.

## How was this patch tested?

 - Tested manually.

Please review http://spark.apache.org/contributing.html before opening a pull request.
