### PR TITLE
[SNAP-3111] honor spark.task.cpus as a local property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
     scalaVersion = scalaBinaryVersion + '.8'
     hadoopVersion = '2.7.7'
     protobufVersion = '3.6.1'
-    jerseyVersion = '2.27'
+    jerseyVersion = '2.22.2'
     sunJerseyVersion = '1.19.4'
     jettyVersion = '9.2.26.v20180806'
     jettyOldVersion = '6.1.26'

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -14,6 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.unsafe;
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -139,7 +139,15 @@ public final class Platform {
   }
 
   public static long allocateMemory(long size) {
-    return _UNSAFE.allocateMemory(size);
+    try {
+      return _UNSAFE.allocateMemory(size);
+    } catch (OutOfMemoryError oome) {
+      if (oome.getMessage().contains("Direct buffer")) {
+        throw oome;
+      } else {
+        throw new OutOfMemoryError("Direct buffer allocation of size = " + size + " failed");
+      }
+    }
   }
 
   public static void freeMemory(long address) {
@@ -147,7 +155,7 @@ public final class Platform {
   }
 
   public static long reallocateMemory(long address, long oldSize, long newSize) {
-    long newMemory = _UNSAFE.allocateMemory(newSize);
+    long newMemory = allocateMemory(newSize);
     copyMemory(null, address, null, newMemory, oldSize);
     freeMemory(address);
     return newMemory;

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -122,7 +122,6 @@ dependencies {
   compile group: 'org.glassfish.jersey.core', name: 'jersey-server', version: jerseyVersion
   compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
   compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet-core', version: jerseyVersion
-  compile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
   compile group: 'io.netty', name: 'netty-all', version: nettyAllVersion
   compile(group: 'com.clearspring.analytics', name: 'stream', version: streamVersion) {
     exclude(group: 'it.unimi.dsi', module: 'fastutil')

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -295,7 +295,7 @@ private[spark] class Executor(
         val (taskFiles, taskJars, taskProps, taskBytes) =
           Task.deserializeWithDependencies(serializedTask)
 
-        hasNonDefaultCpusPerTask = taskProps.containsKey(TaskSchedulerImpl.CPUS_PER_TASK_PROP)
+        hasNonDefaultCpusPerTask = taskProps.containsKey(TaskSchedulerImpl.CPUS_PER_TASK)
         if (hasNonDefaultCpusPerTask) handleNonDefaultCpusPerTask(init = true)
         // Must be set before updateDependencies() is called, in case fetching dependencies
         // requires access to properties contained within (e.g. for access control).

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -14,6 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.executor
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -14,6 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.scheduler
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -85,6 +85,8 @@ private[spark] abstract class Task[T](
 
   @transient private[spark] var taskDataBytes: Array[Byte] = _
 
+  @transient private[spark] var cpusPerTask: Int = _
+
   protected final def getTaskBytes: Array[Byte] = {
     val bytes = taskDataBytes
     if ((bytes ne null) && bytes.length > 0) bytes else taskBinary.get.value

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -35,7 +35,8 @@ private[spark] class TaskDescription(
     private var _name: String,
     private var _index: Int,    // Index within this task's TaskSet
     @transient private var _serializedTask: ByteBuffer,
-    private[spark] var taskData: TaskData = TaskData.EMPTY)
+    private[spark] var taskData: TaskData = TaskData.EMPTY,
+    @transient private[spark] val cpusPerTask: Int = 1)
   extends Serializable with KryoSerializable {
 
   def taskId: Long = _taskId
@@ -43,8 +44,6 @@ private[spark] class TaskDescription(
   def executorId: String = _executorId
   def name: String = _name
   def index: Int = _index
-
-  @transient private[spark] var cpusPerTask = 1
 
   // Because ByteBuffers are not serializable, wrap the task in a SerializableBuffer
   private val buffer =

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -44,6 +44,8 @@ private[spark] class TaskDescription(
   def name: String = _name
   def index: Int = _index
 
+  @transient private[spark] var cpusPerTask = 1
+
   // Because ByteBuffers are not serializable, wrap the task in a SerializableBuffer
   private val buffer =
     if (_serializedTask ne null) new SerializableBuffer(_serializedTask) else null

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskDescription.scala
@@ -14,6 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.scheduler
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -76,8 +76,7 @@ private[spark] class TaskSchedulerImpl(
   val STARVATION_TIMEOUT_MS = conf.getTimeAsMs("spark.starvation.timeout", "15s")
 
   // CPUs to request per task
-  val CPUS_PER_TASK_PROP = "spark.task.cpus"
-  val CPUS_PER_TASK = conf.getInt(CPUS_PER_TASK_PROP, 1)
+  val CPUS_PER_TASK = conf.getInt(TaskSchedulerImpl.CPUS_PER_TASK_PROP, 1)
 
   // TaskSetManagers are not thread safe, so any access to one should be synchronized
   // on this class.
@@ -251,7 +250,7 @@ private[spark] class TaskSchedulerImpl(
   }
 
   private def getCpusPerTask(taskSet: TaskSetManager): Int = {
-    taskSet.taskSet.properties.getProperty(CPUS_PER_TASK_PROP) match {
+    taskSet.taskSet.properties.getProperty(TaskSchedulerImpl.CPUS_PER_TASK_PROP) match {
       case null => CPUS_PER_TASK
       case s => math.max(s.toInt, CPUS_PER_TASK)
     }
@@ -651,6 +650,9 @@ private[spark] class TaskSchedulerImpl(
 
 
 private[spark] object TaskSchedulerImpl {
+
+  val CPUS_PER_TASK_PROP = "spark.task.cpus"
+
   /**
    * Used to balance containers across hosts.
    *

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -14,6 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.scheduler
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
@@ -28,7 +28,7 @@ private[spark] class TaskSet(
     val stageId: Int,
     val stageAttemptId: Int,
     val priority: Int,
-    val properties: Properties) {
+    var properties: Properties) {
   val id: String = stageId + "." + stageAttemptId
 
   override def toString: String = "TaskSet " + id

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSet.scala
@@ -28,7 +28,7 @@ private[spark] class TaskSet(
     val stageId: Int,
     val stageAttemptId: Int,
     val priority: Int,
-    var properties: Properties) {
+    val properties: Properties) {
   val id: String = stageId + "." + stageAttemptId
 
   override def toString: String = "TaskSet " + id

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -822,6 +822,8 @@ private[spark] class TaskSetManager(
               case s => (s.toInt * 2).toString
             }
           taskSet.properties.setProperty(TaskSchedulerImpl.CPUS_PER_TASK_PROP, newCpusPerTask)
+          tasks(index).localProperties.setProperty(
+            TaskSchedulerImpl.CPUS_PER_TASK_PROP, newCpusPerTask)
           logWarning("Retrying failed task %d in stage %s with %s = %s".format(
             index, taskSet.id, TaskSchedulerImpl.CPUS_PER_TASK_PROP, newCpusPerTask))
         case _ =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -92,7 +92,7 @@ private[spark] class TaskSetManager(
 
   import TaskSchedulerImpl.CPUS_PER_TASK
 
-  // dynamic spark.task.cpus only supported by CoarseGrainedSchedulerBackend
+  // dynamic spark.task.cpus only supported by SnappyCoarseGrainedSchedulerBackend
   private[this] val supportsDynamicCpusPerTask =
     sched.backend.getClass.getName.contains("SnappyCoarseGrainedSchedulerBackend")
 
@@ -846,7 +846,7 @@ private[spark] class TaskSetManager(
           }
           // increase the max retries for such tasks since repeated failures would be common
           // before system stabilizes
-          maxTaskFailures += 12
+          maxTaskFailures += 10
         }
 
         ef.exception

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -810,6 +810,13 @@ private[spark] class TaskSetManager(
             (true, 0)
           }
         }
+        if (printFull) {
+          logWarning(failureReason)
+        } else {
+          logInfo(
+            s"Lost task ${info.id} in stage ${taskSet.id} (TID $tid) on ${info.host}, executor" +
+              s" ${info.executorId}: ${ef.className} (${ef.description}) [duplicate $dupCount]")
+        }
 
         // for next round increase cpusPerTask for OOME/LME
         if (supportsDynamicCpusPerTask && !isZombie && (ef.className.contains("OutOfMemory") ||
@@ -842,13 +849,6 @@ private[spark] class TaskSetManager(
           maxTaskFailures += 12
         }
 
-        if (printFull) {
-          logWarning(failureReason)
-        } else {
-          logInfo(
-            s"Lost task ${info.id} in stage ${taskSet.id} (TID $tid) on ${info.host}, executor" +
-              s" ${info.executorId}: ${ef.className} (${ef.description}) [duplicate $dupCount]")
-        }
         ef.exception
 
       case e: ExecutorLostFailure if !e.exitCausedByApp =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -827,7 +827,7 @@ private[spark] class TaskSetManager(
           // so create a new copy here for the task since we don't want individual
           // tasks in the same TaskSet to repeatedly increase the cpusPerTask
           if (task.localProperties eq taskSet.properties) {
-            task.localProperties = task.localProperties.clone().asInstanceOf[Properties]
+            taskSet.properties = taskSet.properties.clone().asInstanceOf[Properties]
           }
           task.localProperties.setProperty(
             TaskSchedulerImpl.CPUS_PER_TASK_PROP, cpusPerTaskStr)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -92,17 +92,20 @@ private[spark] class TaskSetManager(
 
   import TaskSchedulerImpl.CPUS_PER_TASK
 
+  // dynamic spark.task.cpus only supported by CoarseGrainedSchedulerBackend
   private[this] val supportsDynamicCpusPerTask =
     sched.backend.isInstanceOf[org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend]
+
+  // keep the configured value for spark.task.cpus preferring local job setting if present
   val confCpusPerTask: Int = taskSet.properties.getProperty(CPUS_PER_TASK) match {
     case s if (s ne null) && supportsDynamicCpusPerTask => max(s.toInt, sched.CPUS_PER_TASK)
     case _ => sched.CPUS_PER_TASK
   }
-  // tracks the max of cpusPerTask across all tasks when those
-  // are dynamically incremented for OOME/LME failures
+  // tracks the max of spark.task.cpus across all tasks in this task set
+  // when they are dynamically incremented for OOME/LME failures
   private[spark] var maxCpusPerTask: Int = confCpusPerTask
-  // true when cpusPerTask are incremented dynamically for a task
-  // for OOME/LME failures
+  // true when spark.task.cpus was incremented dynamically for any task
+  // in this task set for an OOME/LME failure
   private[spark] var hasDynamicCpusPerTask: Boolean = false
 
   val taskAttempts = Array.fill[List[TaskInfo]](numTasks)(Nil)
@@ -466,6 +469,20 @@ private[spark] class TaskSetManager(
       dequeueTask(execId, host, allowedLocality).map { case ((index, taskLocality, speculative)) =>
         // Found a task; do some bookkeeping and return a task description
         val task = tasks(index)
+        // increase the cpusPerTask of this task so that this sees less failures when scheduled
+        if (hasDynamicCpusPerTask) {
+          var sumCpusPerTask = 0.0
+          var countCpusPerTask = 0
+          for (t <- tasks if (t ne task) && t.cpusPerTask > confCpusPerTask) {
+            sumCpusPerTask += t.cpusPerTask
+            countCpusPerTask += 1
+          }
+          if (countCpusPerTask > 0) {
+            // use midway between average and max because both can be skewed
+            task.cpusPerTask = math.min(maxCpusPerTask, math.max(task.cpusPerTask,
+              math.ceil((sumCpusPerTask / countCpusPerTask + maxCpusPerTask) / 2.0).toInt))
+          }
+        }
         val taskId = sched.newTaskId()
         // Do various bookkeeping
         copiesRunning(index) += 1
@@ -749,6 +766,7 @@ private[spark] class TaskSetManager(
     }
     removeRunningTask(tid)
     info.markFinished(state)
+    var maxTaskFailures = this.maxTaskFailures
     val index = info.index
     copiesRunning(index) -= 1
     var accumUpdates: Seq[AccumulatorV2[_, _]] = Seq.empty
@@ -792,6 +810,38 @@ private[spark] class TaskSetManager(
             (true, 0)
           }
         }
+
+        // for next round increase cpusPerTask for OOME/LME
+        if (supportsDynamicCpusPerTask && !isZombie && (ef.className.contains("OutOfMemory") ||
+            ef.className.contains("LowMemoryException"))) {
+          hasDynamicCpusPerTask = true
+          val task = tasks(index)
+          // apply a reasonable upper limit on dynamic cpusPerTask
+          if (task.cpusPerTask < min(confCpusPerTask + 4, sched.maxAvailableCpus / 2)) {
+            task.cpusPerTask += 1
+            // update maxCpusPerTask tracked in the TaskSetManager which is
+            // required for the check in TaskSchedulerImpl.resourceOfferSingleTaskSet
+            if (task.cpusPerTask > maxCpusPerTask) {
+              maxCpusPerTask = task.cpusPerTask
+            }
+          }
+          // set in properties, if required, for Executor to allow taking any required actions
+          // for OOME/LME (mostly to avoid catastrophic node failure as far as possible)
+          if (!task.localProperties.containsKey(CPUS_PER_TASK)) {
+            task.localProperties.setProperty(CPUS_PER_TASK, task.cpusPerTask.toString)
+          }
+          if (printFull) {
+            logWarning("Retrying failed task %s in stage %s (TID %d) increasing %s to %d [dup=%d]"
+                .format(info.id, taskSet.id, tid, CPUS_PER_TASK, task.cpusPerTask, dupCount))
+          } else {
+            logInfo("Retrying failed task %s in stage %s (TID %d) increasing %s to %d"
+                .format(info.id, taskSet.id, tid, CPUS_PER_TASK, task.cpusPerTask))
+          }
+          // increase the max retries for such tasks since repeated failures would be common
+          // before system stabilizes
+          maxTaskFailures += 12
+        }
+
         if (printFull) {
           logWarning(failureReason)
         } else {
@@ -828,47 +878,6 @@ private[spark] class TaskSetManager(
         info.host, info.executorId, index))
       assert (null != failureReason)
       numFailures(index) += 1
-      var maxTaskFailures = this.maxTaskFailures
-      // for next round increase cpusPerTask for OOME/LME
-      reason match {
-        case e: ExceptionFailure if supportsDynamicCpusPerTask &&
-            (e.className.contains("OutOfMemory") || e.className.contains("LowMemoryException")) =>
-          hasDynamicCpusPerTask = true
-          val task = tasks(index)
-          // apply a reasonable upper limit on dynamic cpusPerTask
-          if (task.cpusPerTask < min(confCpusPerTask + 4, sched.maxAvailableCpus / 2)) {
-            task.cpusPerTask += 1
-            // update maxCpusPerTask tracked in the TaskSetManager which is
-            // required for the check in TaskSchedulerImpl.resourceOfferSingleTaskSet
-            if (task.cpusPerTask > maxCpusPerTask) {
-              maxCpusPerTask = task.cpusPerTask
-            }
-            // increase the cpusPerTask of the other tasks to average of ones with increased
-            // cpusPerTask so that they see less failures when scheduled
-            var sumDynamicCpusPerTask = 0.0
-            var countDynamicCpusPerTask = 0
-            for (t <- tasks if (t ne task) && t.cpusPerTask > confCpusPerTask) {
-              sumDynamicCpusPerTask += t.cpusPerTask
-              countDynamicCpusPerTask += 1
-            }
-            if (countDynamicCpusPerTask > 0) {
-              for (t <- tasks if (t ne task) && t.cpusPerTask <= confCpusPerTask) {
-                t.cpusPerTask = math.ceil(sumDynamicCpusPerTask / countDynamicCpusPerTask).toInt
-              }
-            }
-          }
-          // set in properties, if required, for Executor to allow handling OOME/LME
-          if (!task.localProperties.containsKey(CPUS_PER_TASK)) {
-            task.localProperties.setProperty(CPUS_PER_TASK, task.cpusPerTask.toString)
-          }
-          logWarning("Retrying failed task %s in stage %s (TID %d) with %s = %s".format(
-            info.id, taskSet.id, tid, CPUS_PER_TASK, task.cpusPerTask))
-          // increase the max retries for such tasks since repeated failures would be common
-          // before system stabilizes
-          maxTaskFailures += 12
-
-        case _ =>
-      }
       if (numFailures(index) >= maxTaskFailures) {
         logError("Task %d in stage %s failed %d times; aborting job".format(
           index, taskSet.id, maxTaskFailures))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 /*
- * Changes for SnappyData data platform.
+ * Changes for TIBCO ComputeDB data platform.
  *
- * Portions Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -469,7 +469,7 @@ private[spark] class TaskSetManager(
       dequeueTask(execId, host, allowedLocality).map { case ((index, taskLocality, speculative)) =>
         // Found a task; do some bookkeeping and return a task description
         val task = tasks(index)
-        // increase the cpusPerTask of this task so that this sees less failures when scheduled
+        // increase the cpusPerTask of this task so that this has less failures when scheduled
         if (hasDynamicCpusPerTask) {
           var sumCpusPerTask = 0.0
           var countCpusPerTask = 0

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 /*
- * Changes for SnappyData data platform.
+ * Changes for TIBCO ComputeDB data platform.
  *
- * Portions Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -134,11 +134,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     override def receive: PartialFunction[Any, Unit] = {
       case StatusUpdate(executorId, taskId, state, data) =>
-        scheduler.statusUpdate(taskId, state, data.value)
+        val cpusPerTask = scheduler.statusUpdate(taskId, state, data.value)
         if (TaskState.isFinished(state)) {
           executorDataMap.get(executorId) match {
             case Some(executorInfo) =>
-              executorInfo.freeCores += scheduler.CPUS_PER_TASK
+              executorInfo.freeCores += cpusPerTask
               makeOffers(executorId)
             case None =>
               // Ignoring the update since we don't know about the executor.
@@ -304,7 +304,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               if (!executorTaskGroup.addTask(task, taskLimit, maxRpcMessageSize)) {
                 // send this task separately
                 val executorData = executorTaskGroup.executorData
-                executorData.freeCores -= scheduler.CPUS_PER_TASK
+                executorData.freeCores -= task.cpusPerTask
                 scheduler.sc.env.taskLogger.logInfo(
                   s"Launching task ${task.taskId} on executor id: " +
                     s"${task.executorId} hostname: ${executorData.executorHost}.")
@@ -321,7 +321,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         val taskGroup = executorTaskGroup.taskGroup
         val executorData = executorTaskGroup.executorData
 
-        executorData.freeCores -= (scheduler.CPUS_PER_TASK * taskGroup.length)
+        executorData.freeCores -= taskGroup.foldLeft(0)(_ + _.cpusPerTask)
         logDebug(s"Launching tasks ${taskGroup.map(_.taskId).mkString(",")} on " +
             s"executor id: $executorId hostname: ${executorData.executorHost}.")
         executorData.executorEndpoint.send(LaunchTasks(taskGroup,

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -124,6 +124,9 @@ class CommandBuilderUtils {
     if (vendorString.contains("OpenJDK")) {
       return JavaVendor.OpenJDK;
     }
+    if (System.getProperty("java.vm.name").contains("OpenJDK")) {
+      return JavaVendor.OpenJDK;
+    }
     return JavaVendor.Unknown;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- spark.task.cpus when set as local property then it overrides the global one if it is larger
- only supported for SnappyCoarseGrainedSchedulerBackend
- dynamically increase per-task spark.task.cpus (stored as separate variable in Task and
  TaskDescription) in case of OOME/LME exceptions; increase max allowed failures for such tasks
- track max spark.task.cpus of all tasks in TaskSetManager so that scheduler can use that to
  determine enough freeCores on an executor
- on task OOME/LME failures that lead to dynamic increment of spark.task.cpus, also increment
  the same on other pending tasks in TaskSet so that they don't go through the failure/retry cycle
- callbacks added to Executor to handle OOME/LME cleanly for tasks that have this property set
- remove System.exit call in Executor and instead invoke uncaught exception handler
- corrected a case of lead failure due to DAGScheduler exit in task cancellation where taskId could
   be missing from TaskSchedulerImpl.taskIdToExecutorId
- add "Direct buffer" to exception message if not present for off-heap memory allocation failures
  because SD/Gem layers depend on that to ignore as non-heap (SystemFailure.isJVMFailureError)

## How was this patch tested?

precheckin -Pstore -Pspark