### PR TITLE
[SNAPPYDATA] add SnappyData builtin functions by reflection

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/SparkSnappyUtils.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*
- * Copyright (c) 2018 SnappyData, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -40,16 +40,41 @@ import org.apache.spark.util.Utils
 object SparkSnappyUtils {
 
   val SNAPPY_UNIFIED_MEMORY_MANAGER_CLASS = "org.apache.spark.memory.SnappyUnifiedMemoryManager"
+  val SNAPPY_DATA_FUNCTIONS_CLASS = "io.snappydata.SnappyDataFunctions"
+  val SNAPPY_ENT_FUNCTIONS_CLASS = "org.apache.spark.sql.execution.SnappyContextAQPFunctions"
 
   def loadSnappyManager(conf: SparkConf, numUsableCores: Int): Option[MemoryManager] = {
+
     try {
       Some(Utils.classForName(SNAPPY_UNIFIED_MEMORY_MANAGER_CLASS)
           .getConstructor(classOf[SparkConf], classOf[Int])
           .newInstance(conf, Int.box(numUsableCores))
           .asInstanceOf[MemoryManager])
     } catch {
-      case ex: ClassNotFoundException => None
+      case _: ClassNotFoundException => None
     }
   }
 
+  /**
+   * This will return Seq[(String, ExpressionInfo, FunctionBuilder)]
+   */
+  def additionalBuiltinFunctions: Seq[Any] = {
+    val baseFunctions = try {
+      val functionsClass = Utils.classForName(SNAPPY_DATA_FUNCTIONS_CLASS)
+      val builtin = functionsClass.getMethod("builtin")
+      builtin.setAccessible(true)
+      builtin.invoke(null).asInstanceOf[Seq[Any]]
+    } catch {
+      case _: Exception => Nil
+    }
+    val entFunctions = try {
+      val functionsClass = Utils.classForName(SNAPPY_ENT_FUNCTIONS_CLASS)
+      val builtin = functionsClass.getMethod("builtin")
+      builtin.setAccessible(true)
+      builtin.invoke(null).asInstanceOf[Seq[Any]]
+    } catch {
+      case _: Exception => Nil
+    }
+    baseFunctions ++ entFunctions
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -14,9 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Changes for TIBCO ComputeDB data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
 
 package org.apache.spark.sql.api.python
 
+import org.apache.spark.SparkSnappyUtils
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
@@ -27,6 +46,10 @@ private[sql] object PythonSQLUtils {
 
   // This is needed when generating SQL documentation for built-in functions.
   def listBuiltinFunctionInfos(): Array[ExpressionInfo] = {
-    FunctionRegistry.functionSet.flatMap(f => FunctionRegistry.builtin.lookupFunction(f)).toArray
+    // noinspection ConvertibleToMethodValue
+    val base = FunctionRegistry.functionSet.flatMap(FunctionRegistry.builtin.lookupFunction(_))
+    val extra = SparkSnappyUtils.additionalBuiltinFunctions
+        .asInstanceOf[Seq[(String, ExpressionInfo, Any)]].map(_._2)
+    if (extra.nonEmpty) (base ++ extra).toArray else base.toArray
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The function descriptions loaded by reflection are used for SQL documentation generation by
PythonSQLUtils

## How was this patch tested?

precheckin buildSqlFuncDocs