### PR TITLE
[SDENT-62] Making method synchronized

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -177,7 +177,7 @@ private[spark] class DiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolea
     doStop()
   }
 
-  private def doStop(): Unit = {
+  private def doStop(): Unit = synchronized {
     if (deleteFilesOnStop) {
       localDirs.foreach { localDir =>
         if (localDir.isDirectory() && localDir.exists()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Making `org.apache.spark.storage.DiskBlockManager#doStop` method
synchronized as it is being invoked concurrently by two threads while
shutting down the executor which sometimes results in one of the
thread failing with IOException as the file is already deleted by the other
thread. Although this doesn't leave any orphan files, the exception is
logged on the logs causing confusion.

## How was this patch tested?
Manual test. 
Can be reproduced easily by adding a sleep interval of 4-5 seconds at
the beginning of the method: `org.apache.spark.storage.DiskBlockManager#stop`