### PR TITLE
[SNAP-3033] - Fixing a failing test in snappy compatibility suite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.streaming
 
-import java.lang.reflect.Field
 import java.util.UUID
 
 import scala.collection.mutable
@@ -28,7 +27,6 @@ import org.scalatest.concurrent.AsyncAssertions.Waiter
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.BeforeAndAfter
-import org.scalatest.PrivateMethodTester._
 
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler._
@@ -408,8 +406,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
   }
 
   private def addedListeners(session: SparkSession = spark): Array[StreamingQueryListener] = {
-    val listenerBus: Field = getListenerBusField
-    listenerBus.get(session.streams).asInstanceOf[StreamingQueryListenerBus].listeners
+    getListenerBusField.get(session.streams).asInstanceOf[StreamingQueryListenerBus].listeners
         .toArray.map(_.asInstanceOf[StreamingQueryListener])
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The reason behind the failure was one of the private fields of the
`StreamingQueryManager` class was being accessed using scala test's
`PrivateMethod`. However, `SnappyStreamingQueryManager` introduced as
part of SNAP-3033 does not contain the same private field hence we are
accessing the same field from the superclass using reflection.

## How was this patch tested?
Run the test

## Related PRs

https://github.com/SnappyDataInc/snappydata/pull/1456/