### PR TITLE
[SPARK-24717][SS] Split out max retain version of state for memory in…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -514,6 +514,15 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val MAX_BATCHES_TO_RETAIN_IN_MEMORY = buildConf("spark.sql.streaming.maxBatchesToRetainInMemory")
+    .internal()
+    .doc("The maximum number of batches which will be retained in memory to avoid " +
+      "loading from files. The value adjusts a trade-off between memory usage vs cache miss: " +
+      "'2' covers both success and direct failure cases, '1' covers only success case, " +
+      "and '0' covers extreme case - disable cache to maximize memory size of executors.")
+    .intConf
+    .createWithDefault(2)
+
   val UNSUPPORTED_OPERATION_CHECK_ENABLED =
     SQLConfigBuilder("spark.sql.streaming.unsupportedOperationCheck")
       .internal()
@@ -726,6 +735,8 @@ class SQLConf extends Serializable with Logging {
     getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
+
+  def maxBatchesToRetainInMemory: Int = getConf(MAX_BATCHES_TO_RETAIN_IN_MEMORY)
 
   def parquetFilterPushDown: Boolean = getConf(PARQUET_FILTER_PUSHDOWN_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -514,7 +514,8 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
-  val MAX_BATCHES_TO_RETAIN_IN_MEMORY = buildConf("spark.sql.streaming.maxBatchesToRetainInMemory")
+  val MAX_BATCHES_TO_RETAIN_IN_MEMORY =
+    SQLConfigBuilder("spark.sql.streaming.maxBatchesToRetainInMemory")
     .internal()
     .doc("The maximum number of batches which will be retained in memory to avoid " +
       "loading from files. The value adjusts a trade-off between memory usage vs cache miss: " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -79,7 +79,7 @@ private[state] class HDFSBackedStateStoreProvider(
 
   /** Implementation of [[StateStore]] API which is backed by a HDFS-compatible file system */
   class HDFSBackedStateStore(val version: Long, mapToUpdate: MapType)
-      extends StateStore {
+    extends StateStore {
 
     /** Trait and classes representing the internal state of the store */
     trait STATE
@@ -341,18 +341,6 @@ private[state] class HDFSBackedStateStoreProvider(
     }
   }
 
-  def rowToString(row: UnsafeRow): String = {
-    row.getUTF8String(0).toString
-  }
-
-  def rowToInt(row: UnsafeRow): Int = {
-    row.getInt(0)
-  }
-
-  def readableMap(newMap : MapType) {
-    newMap.asScala.map { entry => rowToString(entry._1) -> rowToInt(entry._2) }.toMap
-  }
-
   /** Load the required version of the map data from the backing files */
   private def loadMap(version: Long): MapType = {
     if (version <= 0) return new MapType
@@ -561,7 +549,7 @@ private[state] class HDFSBackedStateStoreProvider(
             fs.delete(f.path, true)
           }
           logInfo(s"Deleted files older than ${earliestFileToRetain.version} for $this: " +
-              filesToDelete.mkString(", "))
+            filesToDelete.mkString(", "))
         }
       }
     } catch {
@@ -576,9 +564,9 @@ private[state] class HDFSBackedStateStoreProvider(
     require(allFiles.exists(_.version == version))
 
     val latestSnapshotFileBeforeVersion = allFiles
-        .filter(_.isSnapshot == true)
-        .takeWhile(_.version <= version)
-        .lastOption
+      .filter(_.isSnapshot == true)
+      .takeWhile(_.version <= version)
+      .lastOption
     val deltaBatchFiles = latestSnapshotFileBeforeVersion match {
       case Some(snapshotFile) =>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java._
 import java.io.{DataInputStream, DataOutputStream, FileNotFoundException, IOException}
 
 import scala.collection.JavaConverters._
@@ -71,13 +72,14 @@ private[state] class HDFSBackedStateStoreProvider(
     valueSchema: StructType,
     storeConf: StateStoreConf,
     hadoopConf: Configuration
-  ) extends StateStoreProvider with Logging {
+) extends StateStoreProvider with Logging {
 
-  type MapType = java.util.HashMap[UnsafeRow, UnsafeRow]
+  val numberOfVersionsToRetainInMemory = storeConf.maxVersionsToRetainInMemory
+  type MapType = util.HashMap[UnsafeRow, UnsafeRow]
 
   /** Implementation of [[StateStore]] API which is backed by a HDFS-compatible file system */
   class HDFSBackedStateStore(val version: Long, mapToUpdate: MapType)
-    extends StateStore {
+      extends StateStore {
 
     /** Trait and classes representing the internal state of the store */
     trait STATE
@@ -88,7 +90,7 @@ private[state] class HDFSBackedStateStoreProvider(
     private val newVersion = version + 1
     private val tempDeltaFile = new Path(baseDir, s"temp-${Random.nextLong}")
     private lazy val tempDeltaFileStream = compressStream(fs.create(tempDeltaFile, true))
-    private val allUpdates = new java.util.HashMap[UnsafeRow, StoreUpdate]()
+    private val allUpdates = new util.HashMap[UnsafeRow, StoreUpdate]()
 
     @volatile private var state: STATE = UPDATING
     @volatile private var finalDeltaFile: Path = null
@@ -140,7 +142,7 @@ private[state] class HDFSBackedStateStoreProvider(
               // Value did not exist in previous version and was added, should not appear in updates
               allUpdates.remove(key)
             case Some(ValueRemoved(_, _)) =>
-              // Remove already in update map, no need to change
+            // Remove already in update map, no need to change
           }
           writeToDeltaFile(tempDeltaFileStream, ValueRemoved(key, value))
         }
@@ -241,7 +243,7 @@ private[state] class HDFSBackedStateStoreProvider(
 
   /* Internal classes and methods */
 
-  private val loadedMaps = new mutable.HashMap[Long, MapType]
+  private val loadedMaps = new util.TreeMap[Long, MapType](Ordering[Long].reverse)
   private val baseDir =
     new Path(id.checkpointLocation, s"${id.operatorId}/${id.partitionId.toString}")
   private val fs = baseDir.getFileSystem(hadoopConf)
@@ -269,9 +271,41 @@ private[state] class HDFSBackedStateStoreProvider(
       } else if (!fs.rename(tempDeltaFile, finalDeltaFile)) {
         throw new IOException(s"Failed to rename $tempDeltaFile to $finalDeltaFile")
       }
-      loadedMaps.put(newVersion, map)
+      putStateIntoStateCacheMap(newVersion, map)
       finalDeltaFile
     }
+  }
+
+  /** This method is intended to be only used for unit test(s). DO NOT TOUCH ELEMENTS IN MAP! */
+  private[state] def getLoadedMaps(): util.SortedMap[Long, MapType] = synchronized {
+    // shallow copy as a minimal guard
+    loadedMaps.clone().asInstanceOf[util.SortedMap[Long, MapType]]
+  }
+
+  private def putStateIntoStateCacheMap(newVersion: Long, map: MapType): Unit = synchronized {
+    if (numberOfVersionsToRetainInMemory <= 0) {
+      if (loadedMaps.size() > 0) loadedMaps.clear()
+      return
+    }
+
+    while (loadedMaps.size() > numberOfVersionsToRetainInMemory) {
+      loadedMaps.remove(loadedMaps.lastKey())
+    }
+
+    val size = loadedMaps.size()
+    if (size == numberOfVersionsToRetainInMemory) {
+      val versionIdForLastKey = loadedMaps.lastKey()
+      if (versionIdForLastKey > newVersion) {
+        // this is the only case which we can avoid putting, because new version will be placed to
+        // the last key and it should be evicted right away
+        return
+      } else if (versionIdForLastKey < newVersion) {
+        // this case needs removal of the last key before putting new one
+        loadedMaps.remove(versionIdForLastKey)
+      }
+    }
+
+    loadedMaps.put(newVersion, map)
   }
 
   /**
@@ -280,7 +314,7 @@ private[state] class HDFSBackedStateStoreProvider(
    */
   private[state] def latestIterator(): Iterator[(UnsafeRow, UnsafeRow)] = synchronized {
     val versionsInFiles = fetchFiles().map(_.version).toSet
-    val versionsLoaded = loadedMaps.keySet
+    val versionsLoaded = loadedMaps.keySet.asScala
     val allKnownVersions = versionsInFiles ++ versionsLoaded
     if (allKnownVersions.nonEmpty) {
       loadMap(allKnownVersions.max).entrySet().iterator().asScala.map { x =>
@@ -307,17 +341,29 @@ private[state] class HDFSBackedStateStoreProvider(
     }
   }
 
+  def rowToString(row: UnsafeRow): String = {
+    row.getUTF8String(0).toString
+  }
+
+  def rowToInt(row: UnsafeRow): Int = {
+    row.getInt(0)
+  }
+
+  def readableMap(newMap : MapType) {
+    newMap.asScala.map { entry => rowToString(entry._1) -> rowToInt(entry._2) }.toMap
+  }
+
   /** Load the required version of the map data from the backing files */
   private def loadMap(version: Long): MapType = {
     if (version <= 0) return new MapType
-    synchronized { loadedMaps.get(version) }.getOrElse {
+    synchronized { Option(loadedMaps.get(version)) }.getOrElse {
       val mapFromFile = readSnapshotFile(version).getOrElse {
         val prevMap = loadMap(version - 1)
         val newMap = new MapType(prevMap)
         updateFromDeltaFile(version, newMap)
         newMap
       }
-      loadedMaps.put(version, mapFromFile)
+      putStateIntoStateCacheMap(version, mapFromFile)
       mapFromFile
     }
   }
@@ -478,13 +524,13 @@ private[state] class HDFSBackedStateStoreProvider(
         val lastVersion = files.last.version
         val deltaFilesForLastVersion =
           filesForVersion(files, lastVersion).filter(_.isSnapshot == false)
-        synchronized { loadedMaps.get(lastVersion) } match {
+        synchronized { Option(loadedMaps.get(lastVersion)) } match {
           case Some(map) =>
             if (deltaFilesForLastVersion.size > storeConf.minDeltasForSnapshot) {
               writeSnapshotFile(lastVersion, map)
             }
           case None =>
-            // The last map is not loaded, probably some other instance is in charge
+          // The last map is not loaded, probably some other instance is in charge
         }
 
       }
@@ -507,7 +553,7 @@ private[state] class HDFSBackedStateStoreProvider(
         if (earliestVersionToRetain > 0) {
           val earliestFileToRetain = filesForVersion(files, earliestVersionToRetain).head
           synchronized {
-            val mapsToRemove = loadedMaps.keys.filter(_ < earliestVersionToRetain).toSeq
+            val mapsToRemove = loadedMaps.asScala.keys.filter(_ < earliestVersionToRetain).toSeq
             mapsToRemove.foreach(loadedMaps.remove)
           }
           val filesToDelete = files.filter(_.version < earliestFileToRetain.version)
@@ -515,7 +561,7 @@ private[state] class HDFSBackedStateStoreProvider(
             fs.delete(f.path, true)
           }
           logInfo(s"Deleted files older than ${earliestFileToRetain.version} for $this: " +
-            filesToDelete.mkString(", "))
+              filesToDelete.mkString(", "))
         }
       }
     } catch {
@@ -530,9 +576,9 @@ private[state] class HDFSBackedStateStoreProvider(
     require(allFiles.exists(_.version == version))
 
     val latestSnapshotFileBeforeVersion = allFiles
-      .filter(_.isSnapshot == true)
-      .takeWhile(_.version <= version)
-      .lastOption
+        .filter(_.isSnapshot == true)
+        .takeWhile(_.version <= version)
+        .lastOption
     val deltaBatchFiles = latestSnapshotFileBeforeVersion match {
       case Some(snapshotFile) =>
 
@@ -556,7 +602,7 @@ private[state] class HDFSBackedStateStoreProvider(
     val files: Seq[FileStatus] = try {
       fs.listStatus(baseDir)
     } catch {
-      case _: java.io.FileNotFoundException =>
+      case _: io.FileNotFoundException =>
         Seq.empty
     }
     val versionToFiles = new mutable.HashMap[Long, StoreFile]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -27,6 +27,10 @@ private[streaming] class StateStoreConf(@transient private val conf: SQLConf) ex
   val minDeltasForSnapshot = conf.stateStoreMinDeltasForSnapshot
 
   val minVersionsToRetain = conf.minBatchesToRetain
+
+  /** Maximum count of versions a State Store implementation should retain in memory */
+  val maxVersionsToRetainInMemory: Int = conf.maxBatchesToRetainInMemory
+
 }
 
 private[streaming] object StateStoreConf {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -376,13 +376,13 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
 
   test("maintenance") {
     val conf = new SparkConf()
-        .setMaster("local")
-        .setAppName("test")
-        // Make maintenance thread do snapshots and cleanups very fast
-        .set(StateStore.MAINTENANCE_INTERVAL_CONFIG, "10ms")
-        // Make sure that when SparkContext stops, the StateStore maintenance thread 'quickly'
-        // fails to talk to the StateStoreCoordinator and unloads all the StateStores
-        .set("spark.rpc.numRetries", "1")
+      .setMaster("local")
+      .setAppName("test")
+      // Make maintenance thread do snapshots and cleanups very fast
+      .set(StateStore.MAINTENANCE_INTERVAL_CONFIG, "10ms")
+      // Make sure that when SparkContext stops, the StateStore maintenance thread 'quickly'
+      // fails to talk to the StateStoreCoordinator and unloads all the StateStores
+      .set("spark.rpc.numRetries", "1")
     val opId = 0
     val dir = Utils.createDirectory(tempDir, Random.nextString(5)).toString
     val storeId = StateStoreId(dir, opId, 0)
@@ -696,8 +696,8 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
   }
 
   def getDataFromFiles(
-      provider: HDFSBackedStateStoreProvider,
-      version: Int = -1): Set[(String, Int)] = {
+    provider: HDFSBackedStateStoreProvider,
+    version: Int = -1): Set[(String, Int)] = {
     val reloadedProvider = new HDFSBackedStateStoreProvider(
       provider.id, keySchema, valueSchema, StateStoreConf.empty, new Configuration)
     if (version < 0) {
@@ -739,9 +739,9 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
   }
 
   def corruptFile(
-      provider: HDFSBackedStateStoreProvider,
-      version: Long,
-      isSnapshot: Boolean): Unit = {
+    provider: HDFSBackedStateStoreProvider,
+    version: Long,
+    isSnapshot: Boolean): Unit = {
     val method = PrivateMethod[Path]('baseDir)
     val basePath = provider invokePrivate method()
     val fileName = if (isSnapshot) s"$version.snapshot" else s"$version.delta"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
-import java.io.{File, IOException}
+import java._
+import java.io.File
 import java.net.URI
 
 import scala.collection.JavaConverters._
@@ -26,12 +27,11 @@ import scala.util.Random
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
-import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
+import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
+import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
 
-import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkFunSuite}
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.quietly
@@ -39,10 +39,11 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkFunSuite}
 
 class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMethodTester {
   type MapType = mutable.HashMap[UnsafeRow, UnsafeRow]
-
+  type ProviderMapType = util.HashMap[UnsafeRow, UnsafeRow]
   import StateStoreCoordinatorSuite._
   import StateStoreSuite._
 
@@ -375,13 +376,13 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
 
   test("maintenance") {
     val conf = new SparkConf()
-      .setMaster("local")
-      .setAppName("test")
-      // Make maintenance thread do snapshots and cleanups very fast
-      .set(StateStore.MAINTENANCE_INTERVAL_CONFIG, "10ms")
-      // Make sure that when SparkContext stops, the StateStore maintenance thread 'quickly'
-      // fails to talk to the StateStoreCoordinator and unloads all the StateStores
-      .set("spark.rpc.numRetries", "1")
+        .setMaster("local")
+        .setAppName("test")
+        // Make maintenance thread do snapshots and cleanups very fast
+        .set(StateStore.MAINTENANCE_INTERVAL_CONFIG, "10ms")
+        // Make sure that when SparkContext stops, the StateStore maintenance thread 'quickly'
+        // fails to talk to the StateStoreCoordinator and unloads all the StateStores
+        .set("spark.rpc.numRetries", "1")
     val opId = 0
     val dir = Utils.createDirectory(tempDir, Random.nextString(5)).toString
     val storeId = StateStoreId(dir, opId, 0)
@@ -544,9 +545,159 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
     assert(numDeltaFiles === 3)
   }
 
+  def updateVersionTo(
+      provider: StateStoreProvider,
+      currentVersion: Int,
+      targetVersion: Int): Int = {
+    var newCurrentVersion = currentVersion
+    for (i <- newCurrentVersion until targetVersion) {
+      newCurrentVersion = incrementVersion(provider, i)
+    }
+    require(newCurrentVersion === targetVersion)
+    newCurrentVersion
+  }
+
+  def incrementVersion(provider: StateStoreProvider, currentVersion: Int): Int = {
+    val store = provider.getStore(currentVersion)
+    put(store, "a", currentVersion + 1)
+    store.commit()
+    currentVersion + 1
+  }
+
+  def checkLoadedVersions(
+      loadedMaps: util.SortedMap[Long, ProviderMapType],
+      count: Int,
+      earliestKey: Long,
+      latestKey: Long): Unit = {
+    assert(loadedMaps.size() === count)
+    assert(loadedMaps.firstKey() === earliestKey)
+    assert(loadedMaps.lastKey() === latestKey)
+  }
+
+  def checkVersion(
+      loadedMaps: util.SortedMap[Long, ProviderMapType],
+      version: Long,
+      expectedData: Map[String, Int]): Unit = {
+
+    val originValueMap = loadedMaps.get(version).asScala.map { entry =>
+      rowToString(entry._1) -> rowToInt(entry._2)
+    }.toMap
+
+    assert(originValueMap === expectedData)
+  }
+
+  test("retaining only two latest versions when MAX_BATCHES_TO_RETAIN_IN_MEMORY set to 2") {
+    val provider = newStoreProvider(opId = Random.nextInt, partition = 0,
+      numOfVersToRetainInMemory = 2)
+
+    var currentVersion = 0
+
+    // commit the ver 1 : cache will have one element
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 1))
+    var loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 1, earliestKey = 1, latestKey = 1)
+    checkVersion(loadedMaps, 1, Map("a" -> 1))
+
+    // commit the ver 2 : cache will have two elements
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 2))
+    loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 2, earliestKey = 2, latestKey = 1)
+    checkVersion(loadedMaps, 2, Map("a" -> 2))
+    checkVersion(loadedMaps, 1, Map("a" -> 1))
+
+    // commit the ver 3 : cache has already two elements and adding ver 3 incurs exceeding cache,
+    // and ver 3 will be added but ver 1 will be evicted
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 3))
+    loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 2, earliestKey = 3, latestKey = 2)
+    checkVersion(loadedMaps, 3, Map("a" -> 3))
+    checkVersion(loadedMaps, 2, Map("a" -> 2))
+  }
+
+  // This test was added along with the fix of SPARK-24717 which is available on spark 2.4.
+  // It is failing on snappy-spark destribution which is still on spark version 2.1. This
+  // is because changes on older store version is ignored here in the current version of code:
+  // org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider#commitUpdates
+  // This is not failing on 2.4 because handling of commitUpdates method is changed between 2.1
+  // to 2.4.
+  // Keeping the test code here ignoring it for now. This test can be enabled once we merge
+  // Spark-2.4.
+  ignore("failure after committing with MAX_BATCHES_TO_RETAIN_IN_MEMORY set to 1") {
+    val provider = newStoreProvider(opId = Random.nextInt, partition = 0,
+      numOfVersToRetainInMemory = 1)
+
+    var currentVersion = 0
+
+    // commit the ver 1 : cache will have one element
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 1))
+    var loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 1, earliestKey = 1, latestKey = 1)
+    checkVersion(loadedMaps, 1, Map("a" -> 1))
+
+    // commit the ver 2 : cache has already one elements and adding ver 2 incurs exceeding cache,
+    // and ver 2 will be added but ver 1 will be evicted
+    // this fact ensures cache miss will occur when this partition succeeds commit
+    // but there's a failure afterwards so have to reprocess previous batch
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 2))
+    loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 1, earliestKey = 1, latestKey = 1)
+    checkVersion(loadedMaps, 2, Map("a" -> 2))
+
+    // suppose there has been failure after committing, and it decided to reprocess previous batch
+    currentVersion = 1
+
+    // committing to existing version which is committed partially but abandoned globally
+    val store = provider.getStore(currentVersion)
+    // negative value to represent reprocessing
+    put(store, "a", -2)
+    store.commit()
+    currentVersion += 1
+
+    // make sure newly committed version is reflected to the cache (overwritten)
+    assert(getData(provider) === Set("a" -> -2))
+    loadedMaps = provider.getLoadedMaps()
+    checkLoadedVersions(loadedMaps, count = 1, earliestKey = 2, latestKey = 2)
+    checkVersion(loadedMaps, 2, Map("a" -> -2))
+  }
+
+  test("no cache data with MAX_BATCHES_TO_RETAIN_IN_MEMORY set to 0") {
+    val provider = newStoreProvider(opId = Random.nextInt, partition = 0,
+      numOfVersToRetainInMemory = 0)
+
+    var currentVersion = 0
+
+    // commit the ver 1 : never cached
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 1))
+    var loadedMaps = provider.getLoadedMaps()
+    assert(loadedMaps.size() === 0)
+
+    // commit the ver 2 : never cached
+    currentVersion = incrementVersion(provider, currentVersion)
+    assert(getData(provider) === Set("a" -> 2))
+    loadedMaps = provider.getLoadedMaps()
+    assert(loadedMaps.size() === 0)
+  }
+
+  def getData(
+      provider: HDFSBackedStateStoreProvider,
+      version: Int = -1): Set[(String, Int)] = {
+    val reloadedProvider = newStoreProvider(provider.id)
+    if (version < 0) {
+      reloadedProvider.latestIterator().map(rowsToStringInt).toSet
+    } else {
+      reloadedProvider.getStore(version).iterator().map(rowsToStringInt).toSet
+    }
+  }
+
   def getDataFromFiles(
       provider: HDFSBackedStateStoreProvider,
-    version: Int = -1): Set[(String, Int)] = {
+      version: Int = -1): Set[(String, Int)] = {
     val reloadedProvider = new HDFSBackedStateStoreProvider(
       provider.id, keySchema, valueSchema, StateStoreConf.empty, new Configuration)
     if (version < 0) {
@@ -588,9 +739,9 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
   }
 
   def corruptFile(
-    provider: HDFSBackedStateStoreProvider,
-    version: Long,
-    isSnapshot: Boolean): Unit = {
+      provider: HDFSBackedStateStoreProvider,
+      version: Long,
+      isSnapshot: Boolean): Unit = {
     val method = PrivateMethod[Path]('baseDir)
     val basePath = provider invokePrivate method()
     val fileName = if (isSnapshot) s"$version.snapshot" else s"$version.delta"
@@ -610,15 +761,21 @@ class StateStoreSuite extends SparkFunSuite with BeforeAndAfter with PrivateMeth
     StateStore invokePrivate method(storeId)
   }
 
+  def newStoreProvider(storeId: StateStoreId): HDFSBackedStateStoreProvider = {
+    newStoreProvider(storeId.operatorId, storeId.partitionId, dir = storeId.checkpointLocation)
+  }
+
   def newStoreProvider(
       opId: Long = Random.nextLong,
       partition: Int = 0,
       minDeltasForSnapshot: Int = SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.defaultValue.get,
+      numOfVersToRetainInMemory: Int = SQLConf.MAX_BATCHES_TO_RETAIN_IN_MEMORY.defaultValue.get,
       dir: String = Utils.createDirectory(tempDir, Random.nextString(5)).toString,
       hadoopConf: Configuration = new Configuration()
-    ): HDFSBackedStateStoreProvider = {
+  ): HDFSBackedStateStoreProvider = {
     val sqlConf = new SQLConf()
     sqlConf.setConf(SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT, minDeltasForSnapshot)
+    sqlConf.setConf(SQLConf.MAX_BATCHES_TO_RETAIN_IN_MEMORY, numOfVersToRetainInMemory)
     sqlConf.setConf(SQLConf.MIN_BATCHES_TO_RETAIN, 2)
     new HDFSBackedStateStoreProvider(
       StateStoreId(dir, opId, partition),
@@ -719,5 +876,5 @@ class RenameReturnsFalseFileSystem extends RawLocalFileSystem {
 }
 
 object RenameReturnsFalseFileSystem {
-  val scheme = s"StateStoreSuite${math.abs(Random.nextInt)}fs"
+  val scheme = s"StateStoreSuite${scala.math.abs(Random.nextInt)}fs"
 }


### PR DESCRIPTION
… HDFSBackedStateStoreProvider

This patch proposes breaking down configuration of retaining batch size on state into two pieces: files and in memory (cache). While this patch reuses existing configuration for files, it introduces new configuration, "spark.sql.streaming.maxBatchesToRetainInMemory" to configure max count of batch to retain in memory.

Apply this patch on top of SPARK-24441 (https://github.com/apache/spark/pull/21469), and manually tested in various workloads to ensure overall size of states in memory is around 2x or less of the size of latest version of state, while it was 10x ~ 80x before applying the patch.

Author: Jungtaek Lim <kabhwan@gmail.com>

Closes #21700 from HeartSaVioR/SPARK-24717.