### PR TITLE
Snap 2919 : Implementation of Structured Streaming UI Tab

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-commons.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-commons.js
@@ -64,6 +64,73 @@ function applyNotApplicableCheck(value){
 }
 
 /*
+* Utility function to convert milliseconds value in human readable
+* form Eg "2 days 14 hrs 2 mins"
+*/
+function formatDurationVerbose(ms) {
+
+  function stringify(num, unit) {
+    if (num <= 0) {
+      return "";
+    } else if (num == 1) {
+      return  num + " "+ unit;
+    } else {
+      return num + " "+ unit+'s';
+    }
+  }
+
+  var second = 1000;
+  var minute = 60 * second;
+  var hour = 60 * minute;
+  var day = 24 * hour;
+  var week = 7 * day;
+  var year = 365 * day;
+
+  var msString = "";
+  if (ms >= second && ms % second == 0) {
+    msString = "";
+  } else {
+    msString = (ms % second) + " ms";
+  }
+
+  var secString = stringify(parseInt((ms % minute) / second), "sec");
+  var minString = stringify(parseInt((ms % hour) / minute), "min");
+  var hrString = stringify(parseInt((ms % day) / hour), "hr");
+  var dayString = stringify(parseInt((ms % week) / day), "day");
+  var wkString = stringify(parseInt((ms % year) / week), "wk");
+  var yrString = stringify(parseInt(ms / year), "yr");
+
+  var finalString = msString;
+
+  if(ms >= second ) {
+    finalString = secString + " " + finalString;
+  }
+
+  if(ms >= minute ) {
+    finalString = minString + " " + finalString;
+  }
+
+  if(ms >= hour ) {
+    finalString = hrString + " " + finalString;
+  }
+
+  if(ms >= day ) {
+    finalString = dayString + " " + hrString + " " + minString;
+  }
+
+  if(ms >= week ) {
+    finalString = wkString + " " + finalString;
+  }
+
+  if(ms >= year ) {
+    finalString = yrString  + " " + wkString + " " + hrString;
+  }
+
+  return finalString;
+
+}
+
+/*
  * Utility function to convert given value in Bytes to KB or MB or GB or TB
  *
  */

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -1,11 +1,30 @@
-.main-container {
-  width: 98%; height: auto;
-  top: 130px;
-  bottom: 0;
+/* Snappy streaming CSS */
+
+#AutoUpdateErrorMsgContainer {
   position: absolute;
+  width: 100%;
+  margin-top: -60px;
+}
+
+#AutoUpdateErrorMsg {
+  width: 30%;
+  max-height: 60px;
+  background-color: #F8DFDF;
+  border: 2px solid red;
+  border-radius: 10px;
+  z-index: 2;
+  position: relative;
+  margin: 5px auto;
+  padding: 0px 10px;
   overflow: auto;
-  /*border: solid #DDD 1px;
-  background-color: #F1F1F1;*/
+  display: none;
+  text-align: center;
+  font-weight: bold;
+}
+
+.main-container {
+  width: 100%;
+  margin-top: 15px;
 }
 
 .left-navigation-panel {

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -66,9 +66,8 @@
 }
 
 .basic-details {
-  width: 48%;
+  width: 98%;
   min-width: 250px;
-  height: 100px;
   float: left;
   margin: 10px;
   border: solid 2px darkgray;

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -1,6 +1,6 @@
 .main-container {
   width: 98%; height: auto;
-  top: 158px;
+  top: 130px;
   bottom: 0;
   position: absolute;
   overflow: auto;
@@ -130,10 +130,20 @@
   /*box-shadow: 5px 5px 5px grey;*/
 }
 
-#selectedQueryName {
+#selectedQueryTitle {
+  float: left;
   margin: 10px;
   padding: 10px;
   font-size: 18px;
   font-weight: bold;
+  text-align: left;
+}
+
+#selectedQueryName {
+  float: left;
+  margin: 10px;
+  padding: 10px;
+  font-size: 18px;
+  /*font-weight: bold;*/
   text-align: left;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -1,0 +1,95 @@
+.main-container {
+  width: 98%; height: auto;
+  top: 158px;
+  bottom: 0;
+  position: absolute;
+  overflow: auto;
+  /*border: solid #DDD 1px;
+  background-color: #F1F1F1;*/
+}
+
+.left-navigation-panel {
+  float: left;
+  width: 15%;
+  min-width: 250px;
+  height: 100%;
+  border: solid #B1B1B1 1px;
+  background-color: #F1F1F1;
+}
+
+.right-details-panel {
+  width: 84%;
+  height: 100%;
+  float: right;
+  padding-left: 10px;
+  border: solid #B1B1B1 1px;
+  background-color: #F1F1F1;
+}
+
+.vertical-menu-heading {
+  width: 100%;
+}
+
+.vertical-menu-heading div {
+  padding: 12px;
+  font-weight: bold;
+  font-size: large;
+  text-align: center;
+  background: #A0A0A0;
+}
+
+.vertical-menu {
+  width: 100%;
+}
+
+.vertical-menu a {
+  background-color: #EEE;
+  color: black;
+  display: block;
+  padding: 12px;
+  text-decoration: none;
+}
+
+.vertical-menu a:hover {
+  background-color: #E5E5E5;
+}
+
+.vertical-menu a.active {
+  background-color: #CCC;
+  color: black;
+}
+
+.details-section {
+  text-align: center;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.basic-details {
+  width: 48%;
+  min-width: 250px;
+  height: 100px;
+  float: left;
+  margin: 10px;
+  border: solid 2px darkgray;
+  border-radius: 10px;
+}
+
+.stats-block {
+  min-width: 200px;
+  height: 100px;
+  display: inline-block;
+  margin: 10px;
+  border: solid 2px darkgray;
+  border-radius: 10px;
+}
+
+.graph-container {
+  min-width: 250px;
+  width: 23%;
+  height: 200px;
+  display: inline-block;
+  margin: 10px;
+  border: solid 1px darkgray;
+  /*box-shadow: 5px 5px 5px grey;*/
+}

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -72,15 +72,52 @@
   margin: 10px;
   border: solid 2px darkgray;
   border-radius: 10px;
+  line-height: 25px;
+}
+
+.basic-details-title {
+  float: left;
+  padding: 10px;
+  width: 30%;
+  font-size: medium;
+  font-weight: bold;
+}
+
+.basic-details > div {
+  text-align: left;
+  width: 33%;
+  float: left;
+}
+
+.basic-details-value {
+  padding: 10px;
+  width: 70%;
 }
 
 .stats-block {
   min-width: 200px;
+  width: 15%;
   height: 100px;
   display: inline-block;
   margin: 10px;
   border: solid 2px darkgray;
   border-radius: 10px;
+}
+
+.stats-block > div {
+  margin: 10px;
+  width: auto;
+  height: 80%;
+}
+
+.stats-block-title {
+  height: 50px;
+  font-size: large;
+  font-weight: bold;
+}
+
+.stats-block-value {
+  font-size: 20px;
 }
 
 .graph-container {
@@ -91,4 +128,12 @@
   margin: 10px;
   border: solid 1px darkgray;
   /*box-shadow: 5px 5px 5px grey;*/
+}
+
+#selectedQueryName {
+  margin: 10px;
+  padding: 10px;
+  font-size: 18px;
+  font-weight: bold;
+  text-align: left;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -147,3 +147,8 @@
   /*font-weight: bold;*/
   text-align: left;
 }
+
+/* datatable row selection */
+table.dataTable tbody tr.queryselected {
+    background-color: #c6ccd7;
+}

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.css
@@ -97,20 +97,19 @@
 .basic-details-title {
   float: left;
   padding: 10px;
-  width: 30%;
+  width: 50%;
   font-size: medium;
   font-weight: bold;
 }
 
 .basic-details > div {
   text-align: left;
-  width: 33%;
+  width: 25%;
   float: left;
 }
 
 .basic-details-value {
   padding: 10px;
-  width: 70%;
 }
 
 .stats-block {

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -1,5 +1,213 @@
 
-function callme(obj) {
-  alert("you called me ? " + obj.id);
-  // window.location = '/structurestreaming/?query=' + obj.id;
+function displayQueryStatistics(queryId) {
+  var queryStats = {};
+  if(selectedQueryUUID == "") {
+    queryStats = streamingQueriesGridData[0];
+  } else {
+    queryStats = streamingQueriesGridData.find(obj => obj.queryUUID == queryId);
+  }
+  // set current selected
+  selectedQueryUUID = queryStats.queryUUID;
+
+  $("#selectedQueryName").html(queryStats.queryName);
+  $("#startDateTime").html(queryStats.queryStartTimeText);
+  $("#uptime").html(queryStats.queryUptimeText);
+  $("#numBatchesProcessed").html(queryStats.numBatchesProcessed);
+  var statusText = queryStats.isActive ? "Active" : "Inactive"
+  $("#status").html(statusText);
+  $("#totalInputRows").html(queryStats.totalInputRows);
+  $("#totalInputRowsPerSec").html(queryStats.avgInputRowsPerSec);
+  $("#totalProcessedRowsPerSec").html(queryStats.avgProcessedRowsPerSec);
+  $("#totalProcessingTime").html(queryStats.totalProcessingTime);
+  $("#avgProcessingTime").html(queryStats.avgProcessingTime);
+
+  updateCharts(queryStats);
+
+  $("#sourcesDetailsContainer").html(queryStats.sources );
+  $("#sinkDetailsContainer").html(queryStats.sink );
 }
+
+function updateCharts(queryStats) {
+  // Load charts library if not already loaded
+  if(!isGoogleChartLoaded) {
+    // Set error message
+    $("#googleChartsErrorMsg").show();
+    return;
+  }
+
+  var numInputRowsChartData = new google.visualization.DataTable();
+  numInputRowsChartData.addColumn('datetime', 'Time of Day');
+  numInputRowsChartData.addColumn('number', 'Input Records');
+
+  var inputVsProcessedRowsChartData = new google.visualization.DataTable();
+  inputVsProcessedRowsChartData.addColumn('datetime', 'Time of Day');
+  inputVsProcessedRowsChartData.addColumn('number', 'Input Records Per Sec');
+  inputVsProcessedRowsChartData.addColumn('number', 'Processed Records Per Sec');
+
+  var processingTimeChartData = new google.visualization.DataTable();
+  processingTimeChartData.addColumn('datetime', 'Time of Day');
+  processingTimeChartData.addColumn('number', 'Processing Time');
+
+  var timeLine = queryStats.timeLine;
+  var numInputRowsTrend = queryStats.numInputRowsTrend;
+  var inputRowsPerSecondTrend = queryStats.inputRowsPerSecondTrend;
+  var processedRowsPerSecondTrend = queryStats.processedRowsPerSecondTrend;
+  var processingTimeTrend = queryStats.processingTimeTrend;
+
+  for(var i=0 ; i < timeLine.length ; i++) {
+    var timeX = new Date(timeLine[i]);
+
+    numInputRowsChartData.addRow([
+        timeX,
+        numInputRowsTrend[i]]);
+
+    inputVsProcessedRowsChartData.addRow([
+        timeX,
+        inputRowsPerSecondTrend[i],
+        processedRowsPerSecondTrend[i]]);
+
+     processingTimeChartData.addRow([
+        timeX,
+        processingTimeTrend[i]]);
+  }
+
+  numInputRowsChartOptions = {
+    title: 'Input Records',
+    curveType: 'function',
+    legend: { position: 'bottom' },
+    colors:['#2139EC'],
+    crosshair: { trigger: 'focus' },
+    hAxis: {
+      format: 'HH:mm'
+    }
+  };
+
+  inputVsProcessedRowsChartOptions = {
+    title: 'Input vs Processed Records per Sec',
+    curveType: 'function',
+    legend: { position: 'bottom' },
+    colors:['#2139EC', '#E67E22'],
+    crosshair: { trigger: 'focus' },
+    hAxis: {
+      format: 'HH:mm'
+    }
+  };
+
+  processingTimeChartOptions = {
+    title: 'Processing Time',
+    curveType: 'function',
+    legend: { position: 'bottom' },
+    colors:['#2139EC'],
+    crosshair: { trigger: 'focus' },
+    hAxis: {
+      format: 'HH:mm'
+    }
+  };
+
+  var numInputRowsChart = new google.visualization.LineChart(
+        document.getElementById('inputTrendsContainer'));
+  numInputRowsChart.draw(numInputRowsChartData,
+        numInputRowsChartOptions);
+
+  var inputVsProcessedRowsChart = new google.visualization.LineChart(
+        document.getElementById('processingTrendContainer'));
+  inputVsProcessedRowsChart.draw(inputVsProcessedRowsChartData,
+        inputVsProcessedRowsChartOptions);
+
+  var processingTimeChart = new google.visualization.LineChart(
+        document.getElementById('processingTimeContainer'));
+  processingTimeChart.draw(processingTimeChartData,
+        processingTimeChartOptions);
+
+}
+
+function getStreamingQueriesGridConf() {
+  // Streaming Queries Grid Data Table Configurations
+  var streamingQueriesGridConf = {
+    data: streamingQueriesGridData,
+    "dom": '',
+    "columns": [
+      { // Query Names
+        data: function(row, type) {
+                var qNameHtml = '<div style="width:100%; padding-left:10px;"'
+                              + ' onclick="displayQueryStatistics(\''+ row.queryUUID +'\')">'
+                              + row.queryName
+                              + '</div>';
+                return qNameHtml;
+              },
+        "orderable": true
+      }
+    ]
+  }
+  return streamingQueriesGridConf;
+}
+
+function loadStreamingStatsInfo() {
+
+  if(!isGoogleChartLoaded) {
+    $.ajax({
+      url: "https://www.gstatic.com/charts/loader.js",
+      dataType: "script",
+      success: function() {
+        loadGoogleCharts();
+      }
+    });
+  }
+
+  $.ajax({
+    url:"/snappy-streaming/services/streams",
+    dataType: 'json',
+    // timeout: 5000,
+    success: function (response, status, jqXHR) {
+      // on success handler
+
+      streamingQueriesGridData = response[0].allQueries;
+      streamingQueriesGrid.clear().rows.add(streamingQueriesGridData).draw();
+
+      // Display currently selected queries stats
+      displayQueryStatistics(selectedQueryUUID);
+
+    },
+    error: ajaxRequestErrorHandler
+  });
+}
+
+function loadGoogleCharts() {
+
+  if((typeof google === 'object' && typeof google.charts === 'object')) {
+    $("#googleChartsErrorMsg").hide();
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(googleChartsLoaded);
+    isGoogleChartLoaded = true;
+  } else {
+    $("#googleChartsErrorMsg").show();
+  }
+
+}
+
+function googleChartsLoaded() {
+  loadStreamingStatsInfo();
+}
+
+var streamingQueriesGrid;
+var streamingQueriesGridData = [];
+var selectedQueryUUID = "";
+
+$(document).ready(function() {
+
+  loadGoogleCharts();
+
+  $.ajaxSetup({
+      cache : false
+    });
+
+  // Members Grid Data Table
+  streamingQueriesGrid = $('#streamingQueriesGrid').DataTable( getStreamingQueriesGridConf() );
+
+  var streamingStatsUpdateInterval = setInterval(function() {
+    loadStreamingStatsInfo();
+  }, 5000);
+
+
+
+});

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -1,14 +1,16 @@
 
 function displayQueryStatistics(queryId) {
   var queryStats = {};
-  if(selectedQueryUUID == "") {
-    queryStats = streamingQueriesGridData[0];
-  } else {
-    queryStats = streamingQueriesGridData.find(obj => obj.queryUUID == queryId);
-  }
-
-  // return if data is not present
-  if(queryStats == undefined) {
+  if (streamingQueriesGridData.length > 0) {
+    if (selectedQueryUUID == "") {
+      queryStats = streamingQueriesGridData[0];
+    } else {
+      queryStats = streamingQueriesGridData.find(obj => obj.queryUUID == queryId);
+      if (queryStats == undefined) {
+        queryStats = streamingQueriesGridData[0];
+      }
+    }
+  } else { // return if data is not present
     return;
   }
 

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -6,8 +6,17 @@ function displayQueryStatistics(queryId) {
   } else {
     queryStats = streamingQueriesGridData.find(obj => obj.queryUUID == queryId);
   }
-  // set current selected
+  // set current selected query and highlight it in query navigation panel
   selectedQueryUUID = queryStats.queryUUID;
+
+  var divList = $('#streamingQueriesGrid tbody tr td div');
+  for (var i=0 ; i< divList.length ; i++) {
+    if (divList[i].innerText == selectedQueryUUID) {
+      var tr = divList[i].parentNode.parentNode;
+      $(tr).toggleClass('queryselected');
+      break;
+    }
+  }
 
   $("#selectedQueryName").html(queryStats.queryName);
   $("#startDateTime").html(queryStats.queryStartTimeText);
@@ -244,7 +253,8 @@ function getStreamingQueriesGridConf() {
     "columns": [
       { // Query Names
         data: function(row, type) {
-                var qNameHtml = '<div style="width:100%; padding-left:10px;"'
+                var qNameHtml = '<div style="display:none;">' + row.queryUUID + '</div>'
+                              + '<div style="width:100%; padding-left:10px;"'
                               + ' onclick="displayQueryStatistics(\''+ row.queryUUID +'\')">'
                               + row.queryName
                               + '</div>';
@@ -255,6 +265,13 @@ function getStreamingQueriesGridConf() {
     ]
   }
   return streamingQueriesGridConf;
+}
+
+function addDataTableSingleRowSelectionHandler(tableId) {
+  $('#' + tableId + ' tbody').on( 'click', 'tr', function () {
+    $('#' + tableId + ' tbody').children('.queryselected').toggleClass('queryselected');
+    $(this).toggleClass('queryselected');
+  } );
 }
 
 function loadStreamingStatsInfo() {
@@ -320,6 +337,7 @@ $(document).ready(function() {
 
   // Members Grid Data Table
   streamingQueriesGrid = $('#streamingQueriesGrid').DataTable( getStreamingQueriesGridConf() );
+  addDataTableSingleRowSelectionHandler('streamingQueriesGrid');
 
   selectedQuerySourcesGrid = $('#querySourcesGrid').DataTable( getQuerySourcesGridConf() );
 

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -26,7 +26,10 @@ function displayQueryStatistics(queryId) {
 
   $("#selectedQueryName").html(queryStats.queryName);
   $("#startDateTime").html(queryStats.queryStartTimeText);
-  $("#uptime").html(queryStats.queryUptimeText);
+  $("#uptime").html(
+    formatDurationVerbose(queryStats.queryUptime).toLocaleString(navigator.language));
+  $("#triggerInterval").html(
+    formatDurationVerbose(queryStats.trendEventsInterval).toLocaleString(navigator.language));
   $("#numBatchesProcessed").html(queryStats.numBatchesProcessed);
   var statusText = "";
   if (queryStats.isActive) {
@@ -163,12 +166,14 @@ function updateCharts(queryStats) {
 
   var processingTimeChartData = new google.visualization.DataTable();
   processingTimeChartData.addColumn('datetime', 'Time of Day');
+  processingTimeChartData.addColumn('number', 'Processing Threshold');
   processingTimeChartData.addColumn('number', 'Processing Time');
 
   var stateOperatorsStatsChartData = new google.visualization.DataTable();
   stateOperatorsStatsChartData.addColumn('datetime', 'Time of Day');
   stateOperatorsStatsChartData.addColumn('number', 'Total Records');
 
+  var intervalValue = queryStats.trendEventsInterval;
   var timeLine = queryStats.timeLine;
   var numInputRowsTrend = queryStats.numInputRowsTrend;
   var inputRowsPerSecondTrend = queryStats.inputRowsPerSecondTrend;
@@ -190,6 +195,7 @@ function updateCharts(queryStats) {
 
      processingTimeChartData.addRow([
         timeX,
+        intervalValue,
         processingTimeTrend[i]]);
 
      stateOperatorsStatsChartData.addRow([
@@ -223,10 +229,17 @@ function updateCharts(queryStats) {
     title: 'Processing Time',
     // curveType: 'function',
     legend: { position: 'bottom' },
-    colors:['#2139EC'],
+    colors:['#ff0000', '#2139EC'],
     crosshair: { trigger: 'focus' },
     hAxis: {
       format: 'HH:mm'
+    },
+    series: {
+      0: {
+        lineWidth: 1,
+        visibleInLegend: false,
+        pointsVisible: false
+      }
     }
   };
 

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -1,0 +1,5 @@
+
+function callme(obj) {
+  alert("you called me ? " + obj.id);
+  // window.location = '/structurestreaming/?query=' + obj.id;
+}

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -31,10 +31,22 @@ function displayQueryStatistics(queryId) {
   $("#status").html(statusText);
 
   $("#totalInputRows").html(queryStats.totalInputRows.toLocaleString(navigator.language));
-  $("#totalInputRowsPerSec").html(Math.round(queryStats.avgInputRowsPerSec).toLocaleString(navigator.language));
-  $("#totalProcessedRowsPerSec").html(Math.round(queryStats.avgProcessedRowsPerSec).toLocaleString(navigator.language));
-  $("#totalProcessingTime").html(queryStats.totalProcessingTime.toLocaleString(navigator.language) + ' ms');
-  $("#avgProcessingTime").html(queryStats.avgProcessingTime.toLocaleString(navigator.language) + ' ms');
+
+  var qIRPSTrend = queryStats.inputRowsPerSecondTrend;
+  $("#currInputRowsPerSec").html(
+      qIRPSTrend[qIRPSTrend.length - 1].toLocaleString(navigator.language));
+
+  var qPRPSTrend = queryStats.processedRowsPerSecondTrend;
+  $("#currProcessedRowsPerSec").html(
+      qPRPSTrend[qPRPSTrend.length - 1].toLocaleString(navigator.language));
+
+  var qTPT = queryStats.totalProcessingTime;
+  $("#totalProcessingTime").html(
+      formatDurationVerbose(qTPT).toLocaleString(navigator.language));
+
+  var qAPT = queryStats.avgProcessingTime;
+  $("#avgProcessingTime").html(
+      formatDurationVerbose(qAPT).toLocaleString(navigator.language));
 
   updateCharts(queryStats);
 

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -303,7 +303,8 @@ function loadStreamingStatsInfo() {
     dataType: 'json',
     // timeout: 5000,
     success: function (response, status, jqXHR) {
-      // on success handler
+      // Hide error message, if displayed
+      $("#AutoUpdateErrorMsg").hide();
 
       streamingQueriesGridData = response[0].allQueries;
       streamingQueriesGrid.clear().rows.add(streamingQueriesGridData).draw();
@@ -333,6 +334,7 @@ function googleChartsLoaded() {
   loadStreamingStatsInfo();
 }
 
+var isGoogleChartLoaded = false;
 var streamingQueriesGrid;
 var streamingQueriesGridData = [];
 var selectedQueryUUID = "";

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -57,7 +57,9 @@ function displayQueryStatistics(queryId) {
   updateCharts(queryStats);
 
   $("#sourcesDetailsContainer").html(generateSourcesStats(queryStats.sources));
-  $("#sinkDetailsContainer").html(generateSinkStats(queryStats.sink));
+  // $("#sinkDetailsContainer").html(generateSinkStats(queryStats.sink));
+  generateSinkStats(queryStats.sink);
+
 }
 
 function generateSourcesStats(sources) {
@@ -65,16 +67,53 @@ function generateSourcesStats(sources) {
   selectedQuerySourcesGrid.clear().rows.add(selectedQuerySourcesGridData).draw();
 }
 
+const SINKTYPE_CONSOLE        = "CONSOLESINK";
+const SINKTYPE_MEMORY         = "MEMORYSINK";
+const SINKTYPE_FOREACH        = "FOREACHSINK";
+const SINKTYPE_FILESTREAM     = "FILESTREAMSINK";
+const SINKTYPE_SNAPPYSTORE    = "SNAPPYSTORESINK";
+const SINKTYPE_KAFKA          = "KAFKASINK";
+const SINKTYPE_CSV            = "CSVSINK";
+const SINKTYPE_JMX            = "JMXSINK";
+const SINKTYPE_SLF4J          = "SLF4JSINK";
+const SINKTYPE_METRICSSERVLET = "METRICSSERVLET";
+const SINKTYPE_GRAPHITE       = "GRAPHITESINK";
+const SINKTYPE_GANGLIA        = "GANGLIASINK";
+
+
 function generateSinkStats(sink) {
-  var sinkHTML = '<div style="width:100%;">'
-                 + '<div style="padding: 0px 5px; float: left; font-weight: bold;">'
-                   + 'Description:'
-                 + '</div>'
-                 + '<div style="float: left; padding: 0px 5px; text-align: left;"> '
-                   + sink.description
-                 + '</div>'
-               + '</div>';
-  return sinkHTML;
+  var sinkType = "";
+  var sinkDesc = sink.description;
+
+  if (sinkDesc.toUpperCase().includes(SINKTYPE_CONSOLE)) {
+    sinkType = "Console";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_MEMORY)) {
+    sinkType = "Memory";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_FOREACH)) {
+    sinkType = "ForEach";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_FILESTREAM)) {
+    sinkType = "FileStream";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_SNAPPYSTORE)) {
+     sinkType = "SnappyStore";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_KAFKA)) {
+    sinkType = "KAFKA";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_CSV)) {
+    sinkType = "CSV";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_JMX)) {
+    sinkType = "JMX";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_SLF4J)) {
+    sinkType = "SLF4J";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_METRICSSERVLET)) {
+    sinkType = "MetricsServlet";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_GRAPHITE)) {
+    sinkType = "Graphite";
+  } else if (sinkDesc.toUpperCase().includes(SINKTYPE_GANGLIA)) {
+    sinkType = "Ganglia";
+  }
+
+  $("#sinkType").html(sinkType);
+  $("#sinkDescription").html(sinkDesc);
+
 }
 
 function updateCharts(queryStats) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -645,6 +645,22 @@ object SQLConf {
       .intConf
       .createWithDefault(100)
 
+  // For SnappyData
+  val STREAMING_UI_RUNNING_QUERIES_DISPLAY_LIMIT =
+    SQLConfigBuilder("spark.sql.streaming.uiRunningQueriesDisplayLimit")
+        .doc("The number of running streaming queries to be displayed on UI." +
+            "Default value is 20")
+        .intConf
+        .createWithDefault(20)
+
+  // For SnappyData
+  val STREAMING_UI_TRENDS_MAX_SAMPLE_SIZE =
+    SQLConfigBuilder("spark.sql.streaming.uiTrendsMaxSampleSize")
+        .doc("The number of maximum historical data points to be displayed on UI." +
+            "Default value is 60 (i.e 60 data points)")
+        .intConf
+        .createWithDefault(60)
+
   val NDV_MAX_ERROR =
     SQLConfigBuilder("spark.sql.statistics.ndv.maxError")
       .internal()
@@ -719,6 +735,11 @@ class SQLConf extends Serializable with Logging {
   def streamingMetricsEnabled: Boolean = getConf(STREAMING_METRICS_ENABLED)
 
   def streamingProgressRetention: Int = getConf(STREAMING_PROGRESS_RETENTION)
+
+  def streamingUIRunningQueriesDisplayLimit: Int =
+    getConf(STREAMING_UI_RUNNING_QUERIES_DISPLAY_LIMIT)
+
+  def streamingUITrendsMaxSampleSize: Int = getConf(STREAMING_UI_TRENDS_MAX_SAMPLE_SIZE)
 
   def filesMaxPartitionBytes: Long = getConf(FILES_MAX_PARTITION_BYTES)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -714,14 +714,11 @@ class SparkSession private(
   }
 
   private def updateUI() = {
-    // scalastyle:off
-
     val ssqListener = new SnappyStreamingQueryListener(sparkContext)
     this.streams.addListener(ssqListener)
 
     if (sparkContext.ui.isDefined) {
-      logInfo("Updating Web UI [for Snappy Session : this.id]")
-      println("Updating Web UI [for Snappy Session : this.id]")
+      logInfo("Updating Web UI to add structure streaming tab.")
       sparkContext.ui.foreach(ui => {
         var structStreamTabPresent: Boolean = false
         val tabsList = ui.getTabs
@@ -731,27 +728,22 @@ class SparkSession private(
           if (tab.prefix.equalsIgnoreCase("structurestreaming")) {
             structStreamTabPresent = true
             logInfo("Structure Streaming UI Tab is already present.")
-            println(("Structure Streaming UI Tab is already present."))
           }
         })
         // Add Structure Streaming Tab, iff not present
         if (!structStreamTabPresent) {
-          logInfo(("Creating Structure Streaming UI Tab"))
-          println("Creating Structure Streaming UI Tab")
-
+          logInfo("Creating Structure Streaming UI Tab")
           // Streaming web service
           ui.attachHandler(SnappyStreamingApiRootResource.getServletHandler(ui))
           // Streaming tab
           new SnappyStreamingTab(ui, ssqListener)
         }
       })
-      logInfo("Updating Web UI [for Snappy Session : this.id] is Done.")
-      println("Updating Web UI [for Snappy Session : this.id] is Done.")
+      logInfo("Updating Web UI to add structure streaming tab is Done.")
     }
-    // scalastyle:on
   }
 
-  updateUI()
+  updateUI();
 
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -46,6 +46,8 @@ import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types.{DataType, LongType, StructType}
 import org.apache.spark.sql.util.ExecutionListenerManager
+import org.apache.spark.status.api.v1.SnappyStreamingApiRootResource
+import org.apache.spark.ui.SnappyStreamingTab
 import org.apache.spark.util.Utils
 
 
@@ -710,6 +712,46 @@ class SparkSession private(
       AttributeReference(f.name, f.dataType, f.nullable)()
     }
   }
+
+  private def updateUI() = {
+    // scalastyle:off
+
+    val ssqListener = new SnappyStreamingQueryListener(sparkContext)
+    this.streams.addListener(ssqListener)
+
+    if (sparkContext.ui.isDefined) {
+      logInfo("Updating Web UI [for Snappy Session : this.id]")
+      println("Updating Web UI [for Snappy Session : this.id]")
+      sparkContext.ui.foreach(ui => {
+        var structStreamTabPresent: Boolean = false
+        val tabsList = ui.getTabs
+        // Add remaining tabs in tabs list
+        tabsList.foreach(tab => {
+          // Check if Structure Streaming Tab is present or not
+          if (tab.prefix.equalsIgnoreCase("structurestreaming")) {
+            structStreamTabPresent = true
+            logInfo("Structure Streaming UI Tab is already present.")
+            println(("Structure Streaming UI Tab is already present."))
+          }
+        })
+        // Add Structure Streaming Tab, iff not present
+        if (!structStreamTabPresent) {
+          logInfo(("Creating Structure Streaming UI Tab"))
+          println("Creating Structure Streaming UI Tab")
+
+          // Streaming web service
+          ui.attachHandler(SnappyStreamingApiRootResource.getServletHandler(ui))
+          // Streaming tab
+          new SnappyStreamingTab(ui, ssqListener)
+        }
+      })
+      logInfo("Updating Web UI [for Snappy Session : this.id] is Done.")
+      println("Updating Web UI [for Snappy Session : this.id] is Done.")
+    }
+    // scalastyle:on
+  }
+
+  updateUI()
 
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -246,7 +246,7 @@ class StreamExecution(
       }
 
       // `postEvent` does not throw non fatal exception.
-      postEvent(new QueryStartedEvent(id, runId, name))
+      postEvent(new QueryStartedEvent(id, runId, name, trigger))
 
       // Unblock starting thread
       startLatch.countDown()

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
@@ -1,0 +1,95 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.util.UUID
+
+import scala.collection.mutable
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.SparkContext
+
+class SnappyStreamingQueryListener(sparkContext: SparkContext) extends StreamingQueryListener {
+  // scalastyle:off
+
+  val streamingRepo = StreamingRepository.getInstance
+
+  val activeQueries = HashMap.empty[UUID, String]
+  val allQueriesBasicDetails = HashMap.empty[UUID, HashMap[String, Any]]
+  val activeQueryProgress = HashMap.empty[UUID, StreamingQueryProgress]
+  val stoppedQueries = HashMap.empty[UUID, String]
+
+  override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
+    println("====== ====== ====== Query started: event.id :: " + event.id + " | event.name :: " + event.name)
+
+    val queryName = {
+      if (event.name == null || event.name.isEmpty)
+        event.id.toString
+      else
+        event.name
+    }
+
+    activeQueries.put(event.id, event.name)
+    val qMap = mutable.HashMap[String, Any]( "name"->queryName, "startTime" -> System.currentTimeMillis(),
+      "isActive"-> true, "uptime" -> 0, "isRestarted" -> false,
+      "attemptCount" -> 0)
+    allQueriesBasicDetails.put(event.id, qMap)
+
+    streamingRepo.activeQueries.put(event.id, queryName)
+    streamingRepo.allQueries.put(event.id,
+      new StreamingQueryStatistics(event.id, queryName, event.runId, System.currentTimeMillis()))
+
+  }
+
+  override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+    val pr = event.progress
+    activeQueryProgress.put(pr.id, pr)
+    println("====== ====== ====== Query made progress: event.progress :: " + pr.id + " | event.name :: " + pr.name)
+    println(" Query id:: " + pr.id + "\n Time: "+ pr.timestamp + " \n Run id :: " + pr.runId + "\n Batch Id: " + pr.batchId)
+
+    if (streamingRepo.allQueries.contains(pr.id)) {
+      val sqs = streamingRepo.allQueries.get(pr.id).get
+      sqs.updateQueryStatistics(event)
+    } else {
+      val queryName = {
+        if (pr.name == null || pr.name.isEmpty)
+          pr.id.toString
+        else
+          pr.name
+      }
+      val sqs = new StreamingQueryStatistics(pr.id, queryName, pr.runId, System.currentTimeMillis())
+      sqs.updateQueryStatistics(event)
+      streamingRepo.allQueries.put(pr.id, sqs)
+    }
+
+  }
+
+  override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+    println("====== ====== ====== Query terminated: event.id :: " + event.id)
+    activeQueries.remove(event.id)
+
+    val q = streamingRepo.activeQueries.remove(event.id).get
+    streamingRepo.inactiveQueries.put(event.id, q)
+
+    streamingRepo.allQueries.get(event.id).get.setStatus(false)
+  }
+
+  // scalastyle:on
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
@@ -35,7 +35,12 @@ class SnappyStreamingQueryListener(sparkContext: SparkContext) extends Streaming
     }
 
     streamingRepo.allQueries.put(event.id,
-      new StreamingQueryStatistics(event.id, queryName, event.runId, System.currentTimeMillis()))
+      new StreamingQueryStatistics(
+        event.id,
+        queryName,
+        event.runId,
+        System.currentTimeMillis(),
+        event.trigger))
   }
 
   override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
@@ -51,7 +56,11 @@ class SnappyStreamingQueryListener(sparkContext: SparkContext) extends Streaming
           pr.name
         }
       }
-      val sqs = new StreamingQueryStatistics(pr.id, queryName, pr.runId, System.currentTimeMillis())
+      val sqs = new StreamingQueryStatistics(
+                  pr.id,
+                  queryName,
+                  pr.runId,
+                  System.currentTimeMillis())
       sqs.updateQueryStatistics(event)
       streamingRepo.allQueries.put(pr.id, sqs)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
@@ -34,7 +34,7 @@ class SnappyStreamingQueryListener(sparkContext: SparkContext) extends Streaming
       }
     }
 
-    streamingRepo.allQueries.put(event.id,
+    streamingRepo.addQuery(event.id,
       new StreamingQueryStatistics(
         event.id,
         queryName,
@@ -44,30 +44,11 @@ class SnappyStreamingQueryListener(sparkContext: SparkContext) extends Streaming
   }
 
   override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
-    val pr = event.progress
-    if (streamingRepo.allQueries.contains(pr.id)) {
-      val sqs = streamingRepo.allQueries.get(pr.id).get
-      sqs.updateQueryStatistics(event)
-    } else {
-      val queryName = {
-        if (pr.name == null || pr.name.isEmpty) {
-          pr.id.toString
-        } else {
-          pr.name
-        }
-      }
-      val sqs = new StreamingQueryStatistics(
-                  pr.id,
-                  queryName,
-                  pr.runId,
-                  System.currentTimeMillis())
-      sqs.updateQueryStatistics(event)
-      streamingRepo.allQueries.put(pr.id, sqs)
-    }
+    streamingRepo.updateQuery(event.progress)
   }
 
   override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
-    streamingRepo.allQueries.get(event.id).get.setStatus(false)
+    streamingRepo.setQueryStatus(event.id, false)
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -96,7 +96,8 @@ object StreamingQueryListener {
   class QueryStartedEvent private[sql](
       val id: UUID,
       val runId: UUID,
-      val name: String) extends Event
+      val name: String,
+      val trigger: Trigger = ProcessingTime(0L)) extends Event
 
   /**
    * :: Experimental ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
@@ -31,8 +31,6 @@ import org.apache.spark.ui.UIUtils
 class StreamingRepository {
 
   val allQueries = HashMap.empty[UUID, StreamingQueryStatistics]
-  val activeQueries = HashMap.empty[UUID, String]
-  val inactiveQueries = HashMap.empty[UUID, String]
 
 }
 
@@ -42,7 +40,6 @@ object StreamingRepository {
 
   def getInstance: StreamingRepository = _instance
 }
-
 
 
 class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime: Long) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
@@ -1,0 +1,183 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.text.SimpleDateFormat
+import java.util.{Date, TimeZone, UUID}
+
+import scala.collection.mutable.HashMap
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer
+
+import org.apache.spark.ui.UIUtils
+
+// scalastyle:off
+
+class StreamingRepository {
+
+  val allQueries = HashMap.empty[UUID, StreamingQueryStatistics]
+  val activeQueries = HashMap.empty[UUID, String]
+  val inactiveQueries = HashMap.empty[UUID, String]
+
+  // def getAllQueries: mutable.HashMap[UUID, StreamingQueryStatistics] = allQueries
+  // def getActiveQueries: mutable.HashMap[UUID, String] = activeQueries
+  // def getInactiveQueries: mutable.HashMap[UUID, String] = inactiveQueries
+
+}
+
+object StreamingRepository {
+
+  private val _instance: StreamingRepository = new StreamingRepository
+
+  def getInstance: StreamingRepository = _instance
+}
+
+
+
+class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime: Long) {
+
+  private val MAX_SAMPLE_SIZE = 100
+
+  private val simpleDateFormat = new SimpleDateFormat("dd-MMM-YYYY hh:mm:ss")
+  private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // ISO8601
+  timestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+
+  val queryUUID: UUID = qId
+  val queryName: String = qName
+  val queryStartTime: Long = startTime
+  val queryStartTimeText: String = simpleDateFormat.format(startTime)
+  var queryUptime: Long = 0L
+  var queryUptimeText: String = ""
+
+  var runUUID: UUID = runId
+
+  var isActive: Boolean = true
+
+  var currentBatchId: Long = -1L
+
+  var sources = Array.empty[SourceProgress]
+  var sink: SinkProgress = null
+
+  var trendInterval: Int = 0
+
+  var totalInputRows: Long = 0L
+  var avgInputRowsPerSec: Double = 0.0
+  var avgProcessedRowsPerSec: Double = 0.0
+  var totalProcessingTime: Long = 0L
+  var avgProcessingTime: Double = 0.0
+  var numBatchesProcessed: Long = 0L
+
+  val timeLine = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val numInputRowsTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val inputRowsPerSecondTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val processedRowsPerSecondTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val processingTimeTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val batchIds = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+
+  var currStateOpNumRowsTotal = 0L
+  var currStateOpNumRowsUpdated = 0L
+  val stateOpNumRowsTotalTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+  val stateOpNumRowsUpdatedTrend = new CircularFifoBuffer(MAX_SAMPLE_SIZE)
+
+  def updateQueryStatistics(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+    val progress = event.progress
+
+    if(this.currentBatchId < progress.batchId){
+      this.numBatchesProcessed = this.numBatchesProcessed + 1
+    }
+
+    this.currentBatchId = progress.batchId
+    this.batchIds.add(progress.batchId)
+
+    val currDateTime: Date = timestampFormat.parse(progress.timestamp)
+    this.queryUptime = currDateTime.getTime - this.queryStartTime
+    this.queryUptimeText = UIUtils.formatDurationVerbose(this.queryUptime)
+
+    this.timeLine.add(currDateTime.getTime)
+
+    val tmpNumInpRows = { if (progress.numInputRows.isNaN) 0 else progress.numInputRows }
+    this.numInputRowsTrend.add(tmpNumInpRows)
+    this.totalInputRows = this.totalInputRows + tmpNumInpRows
+
+    val tmpInputRowsPerSec = { if (progress.inputRowsPerSecond.isNaN) 0.0 else progress.inputRowsPerSecond }
+    this.inputRowsPerSecondTrend.add(tmpInputRowsPerSec)
+    this.avgInputRowsPerSec = calcAvgOfGivenTrend(this.inputRowsPerSecondTrend)
+
+    val tmpProcessedRowsPerSec = { if (progress.processedRowsPerSecond.isNaN) 0.0 else progress.processedRowsPerSecond }
+    this.processedRowsPerSecondTrend.add(tmpProcessedRowsPerSec)
+    this.avgProcessedRowsPerSec = calcAvgOfGivenTrend(this.processedRowsPerSecondTrend)
+
+    val tmpProcessingTime = progress.durationMs.get("triggerExecution")
+    this.processingTimeTrend.add(tmpProcessingTime)
+    this.totalProcessingTime = this.totalProcessingTime + tmpProcessingTime
+    this.avgProcessingTime = this.totalProcessingTime / this.numBatchesProcessed
+
+    this.sources = progress.sources
+    this.sink = progress.sink
+
+    val stateOperators = progress.stateOperators
+    if (stateOperators.size > 0) {
+
+      var sumAllSTNumRowsTotal = 0L
+      var sumAllSTNumRowsUpdated = 0L
+
+      stateOperators.foreach(so => {
+        sumAllSTNumRowsTotal = sumAllSTNumRowsTotal + so.numRowsTotal
+        sumAllSTNumRowsUpdated = sumAllSTNumRowsUpdated + so.numRowsUpdated
+      })
+
+      if (currStateOpNumRowsTotal < sumAllSTNumRowsTotal) {
+        this.currStateOpNumRowsTotal = sumAllSTNumRowsTotal
+      }
+      this.stateOpNumRowsTotalTrend.add(sumAllSTNumRowsTotal)
+
+      if (currStateOpNumRowsUpdated < sumAllSTNumRowsUpdated) {
+        this.currStateOpNumRowsUpdated = sumAllSTNumRowsUpdated
+      }
+      this.stateOpNumRowsUpdatedTrend.add(sumAllSTNumRowsUpdated)
+
+    }
+  }
+
+  def calcAvgOfGivenTrend (trend: CircularFifoBuffer) : Double = {
+    val arrValues = trend.toArray()
+    var sumOfElements = 0.0
+
+    arrValues.foreach(value => {
+      sumOfElements = sumOfElements + value.asInstanceOf[Double]
+    })
+
+    val avgValue = sumOfElements / arrValues.size
+
+    avgValue
+  }
+
+  def setStatus (status: Boolean) = {
+    this.isActive = status
+  }
+
+}
+
+class StreamingSourceStatistics (queriUUID: UUID, description: String) {
+  var numInputRows: Int = 0
+  var processedRowsPerSecond: Int = 0
+}
+
+class StreamingSinkStatistics (queriUUID: UUID, description: String)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
@@ -42,7 +42,12 @@ object StreamingRepository {
 }
 
 
-class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime: Long) {
+class StreamingQueryStatistics (
+    qId: UUID,
+    qName: String,
+    runId: UUID,
+    startTime: Long,
+    trigger: Trigger = ProcessingTime(0L)) {
 
   private val MAX_SAMPLE_SIZE = 100
 
@@ -58,6 +63,7 @@ class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime
   var queryUptimeText: String = ""
 
   var runUUID: UUID = runId
+  val trendEventsInterval: Long = trigger.asInstanceOf[ProcessingTime].intervalMs
 
   var isActive: Boolean = true
 
@@ -65,8 +71,6 @@ class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime
 
   var sources = Array.empty[SourceProgress]
   var sink: SinkProgress = null
-
-  var trendInterval: Int = 0
 
   var totalInputRows: Long = 0L
   var avgInputRowsPerSec: Double = 0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
@@ -28,17 +28,11 @@ import org.apache.commons.collections.buffer.CircularFifoBuffer
 
 import org.apache.spark.ui.UIUtils
 
-// scalastyle:off
-
 class StreamingRepository {
 
   val allQueries = HashMap.empty[UUID, StreamingQueryStatistics]
   val activeQueries = HashMap.empty[UUID, String]
   val inactiveQueries = HashMap.empty[UUID, String]
-
-  // def getAllQueries: mutable.HashMap[UUID, StreamingQueryStatistics] = allQueries
-  // def getActiveQueries: mutable.HashMap[UUID, String] = activeQueries
-  // def getInactiveQueries: mutable.HashMap[UUID, String] = inactiveQueries
 
 }
 
@@ -112,15 +106,21 @@ class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime
 
     this.timeLine.add(currDateTime.getTime)
 
-    val tmpNumInpRows = { if (progress.numInputRows.isNaN) 0 else progress.numInputRows }
+    val tmpNumInpRows = {
+      if (progress.numInputRows.isNaN) 0 else progress.numInputRows
+    }
     this.numInputRowsTrend.add(tmpNumInpRows)
     this.totalInputRows = this.totalInputRows + tmpNumInpRows
 
-    val tmpInputRowsPerSec = { if (progress.inputRowsPerSecond.isNaN) 0.0 else progress.inputRowsPerSecond }
+    val tmpInputRowsPerSec = {
+      if (progress.inputRowsPerSecond.isNaN) 0.0 else progress.inputRowsPerSecond
+    }
     this.inputRowsPerSecondTrend.add(tmpInputRowsPerSec)
     this.avgInputRowsPerSec = calcAvgOfGivenTrend(this.inputRowsPerSecondTrend)
 
-    val tmpProcessedRowsPerSec = { if (progress.processedRowsPerSecond.isNaN) 0.0 else progress.processedRowsPerSecond }
+    val tmpProcessedRowsPerSec = {
+      if (progress.processedRowsPerSecond.isNaN) 0.0 else progress.processedRowsPerSecond
+    }
     this.processedRowsPerSecondTrend.add(tmpProcessedRowsPerSec)
     this.avgProcessedRowsPerSec = calcAvgOfGivenTrend(this.processedRowsPerSecondTrend)
 
@@ -169,15 +169,8 @@ class StreamingQueryStatistics (qId: UUID, qName: String, runId: UUID, startTime
     avgValue
   }
 
-  def setStatus (status: Boolean) = {
+  def setStatus (status: Boolean): Unit = {
     this.isActive = status
   }
 
 }
-
-class StreamingSourceStatistics (queriUUID: UUID, description: String) {
-  var numInputRows: Int = 0
-  var processedRowsPerSecond: Int = 0
-}
-
-class StreamingSinkStatistics (queriUUID: UUID, description: String)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/SnappyStreamingApiRootResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/SnappyStreamingApiRootResource.scala
@@ -1,0 +1,62 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.status.api.v1
+
+import javax.ws.rs._
+
+import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
+import org.glassfish.jersey.server.ServerProperties
+import org.glassfish.jersey.servlet.ServletContainer
+
+
+/**
+ * Main entry point for serving snappy/spark web application data as json, using JAX-RS.
+ *
+ * Each resource should have endpoints that return **public** classes defined in snappy-api.scala.
+ * Mima binary compatibility checks ensure that we don't inadvertently make changes that break the
+ * api.
+ * The returned objects are automatically converted to json by jackson with JacksonMessageWriter.
+ * In addition, there are a number of tests in HistoryServerSuite that compare the json to "golden
+ * files".  Any changes and additions should be reflected there as well -- see the notes in
+ * HistoryServerSuite.
+ */
+
+// todo : need to add tests to test below apis
+
+@Path("/services")
+class SnappyStreamingApiRootResource extends ApiRequestContext {
+
+  @Path("streams")
+  def getStreams(): StreamsInfoResource = {
+    new StreamsInfoResource
+  }
+}
+
+private[spark] object SnappyStreamingApiRootResource {
+
+  def getServletHandler(uiRoot: UIRoot): ServletContextHandler = {
+    val jerseyContext = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
+    jerseyContext.setContextPath("/snappy-streaming")
+    val holder: ServletHolder = new ServletHolder(classOf[ServletContainer])
+    holder.setInitParameter(ServerProperties.PROVIDER_PACKAGES, "org.apache.spark.status.api.v1")
+    UIRootFromServletContext.setUiRoot(jerseyContext, uiRoot)
+    jerseyContext.addServlet(holder, "/*")
+    jerseyContext
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
@@ -1,0 +1,42 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.status.api.v1
+
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.{GET, Produces}
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.spark.sql.streaming.StreamingRepository
+
+// scalastyle:off
+
+@Produces(Array(MediaType.APPLICATION_JSON))
+private[v1] class StreamsInfoResource {
+  @GET
+  def streamInfo(): Seq[StreamsSummary] = {
+    val streamingRepo = StreamingRepository.getInstance
+
+    val streamsBuff: ListBuffer[StreamsSummary] = ListBuffer.empty[StreamsSummary]
+    streamsBuff += new StreamsSummary (streamingRepo.activeQueries,
+      streamingRepo.inactiveQueries, streamingRepo.allQueries.values.toList)
+
+    streamsBuff.toList
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
@@ -32,8 +32,7 @@ private[v1] class StreamsInfoResource {
     val streamingRepo = StreamingRepository.getInstance
 
     val streamsBuff: ListBuffer[StreamsSummary] = ListBuffer.empty[StreamsSummary]
-    streamsBuff += new StreamsSummary (streamingRepo.activeQueries,
-      streamingRepo.inactiveQueries, streamingRepo.allQueries.values.toList)
+    streamsBuff += new StreamsSummary (streamingRepo.allQueries.values.toList)
 
     streamsBuff.toList
   }

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
@@ -32,7 +32,7 @@ private[v1] class StreamsInfoResource {
     val streamingRepo = StreamingRepository.getInstance
 
     val streamsBuff: ListBuffer[StreamsSummary] = ListBuffer.empty[StreamsSummary]
-    streamsBuff += new StreamsSummary (streamingRepo.allQueries.values.toList)
+    streamsBuff += new StreamsSummary (streamingRepo.getAllQueries.values.toList)
 
     streamsBuff.toList
   }

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/StreamsInfoResource.scala
@@ -25,8 +25,6 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.sql.streaming.StreamingRepository
 
-// scalastyle:off
-
 @Produces(Array(MediaType.APPLICATION_JSON))
 private[v1] class StreamsInfoResource {
   @GET

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/streamapi.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/streamapi.scala
@@ -1,0 +1,32 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package org.apache.spark.status.api.v1
+
+import java.util.UUID
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.streaming.StreamingQueryStatistics
+
+
+class StreamsSummary private[spark](
+    val activeQueries: mutable.HashMap[UUID, String],
+    val inactiveQueries: mutable.HashMap[UUID, String],
+    val allQueries: Seq[StreamingQueryStatistics]
+)

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/streamapi.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/streamapi.scala
@@ -18,15 +18,11 @@
  */
 package org.apache.spark.status.api.v1
 
-import java.util.UUID
-
-import scala.collection.mutable
-
 import org.apache.spark.sql.streaming.StreamingQueryStatistics
 
 
 class StreamsSummary private[spark](
-    val activeQueries: mutable.HashMap[UUID, String],
-    val inactiveQueries: mutable.HashMap[UUID, String],
+    // val activeQueries: mutable.HashMap[UUID, String],
+    // val inactiveQueries: mutable.HashMap[UUID, String],
     val allQueries: Seq[StreamingQueryStatistics]
 )

--- a/sql/core/src/main/scala/org/apache/spark/ui/SnappyStreamingTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/ui/SnappyStreamingTab.scala
@@ -1,0 +1,38 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.ui
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.streaming.SnappyStreamingQueryListener
+
+class SnappyStreamingTab (sparkUI: SparkUI, streamingListener: SnappyStreamingQueryListener)
+    extends SparkUITab(sparkUI, "structurestreaming") with Logging {
+
+  override val name = "Structured Streaming"
+
+  val parent = sparkUI
+  val listener = streamingListener
+
+  attachPage(new SnappyStructuredStreamingPage(this))
+  // Attach Tab
+  parent.attachTab(this)
+  // parent.attachHandler(SnappyStreamingApiRootResource.getServletHandler(parent))
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
@@ -29,8 +29,6 @@ import org.apache.spark.internal.Logging
 private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
     extends WebUIPage("") with Logging {
 
-  val activeQueries = parent.listener.activeQueries
-
   def commonHeaderNodesSnappy: Seq[Node] = {
     <link rel="stylesheet" type="text/css"
           href={UIUtils.prependBaseUri("/static/snappydata/snappy-streaming.css")}/>
@@ -45,17 +43,7 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
 
     val pageHeaderText: String = SnappyStructuredStreamingPage.pageHeaderText
 
-    val mainContent = {
-      val connErrorMsgNode = {
-        <div id="AutoUpdateErrorMsgContainer">
-          <div id="AutoUpdateErrorMsg">
-          </div>
-        </div>
-      }
-      connErrorMsgNode ++ createMainContent
-    }
-
-    val pageContent = commonHeaderNodesSnappy ++ mainContent
+    val pageContent = commonHeaderNodesSnappy ++ createMainContent
 
     UIUtils.headerSparkPage(pageHeaderText, pageContent, parent, Some(500), useDataTables = true)
 
@@ -64,10 +52,20 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
   private def createMainContent: Seq[Node] = {
     val navPanel = createNavigationPanel
     val detailsPanel = createQueryDetailsPanel
+    val connErrorMsgNode = {
+      <div id="AutoUpdateErrorMsgContainer">
+        <div id="AutoUpdateErrorMsg">
+        </div>
+      </div>
+    }
+    val mainPanel = {
+      <div class="main-container">
+        {navPanel ++ detailsPanel}
+      </div>
+    }
 
-    <div class="main-container">
-      {navPanel ++ detailsPanel}
-    </div>
+    connErrorMsgNode ++ mainPanel
+
   }
 
   private def createNavigationPanel: Seq[Node] = {
@@ -166,7 +164,7 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
     </div>
   }
 
-  private def createQueryDetailsEntry (): Seq[Node] = {
+  private def createQueryDetailsEntry: Seq[Node] = {
     <div id="querydetails">
       <div class="container-fluid details-section">
         <div id="selectedQueryTitle" data-toggle="tooltip" title=""

--- a/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
@@ -26,8 +26,6 @@ import scala.xml.Node
 
 import org.apache.spark.internal.Logging
 
-// scalastyle:off
-
 private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
     extends WebUIPage("") with Logging {
 
@@ -81,7 +79,9 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
             <tr>
               <th class="table-th-col-heading" style="font-size: medium;">
                 <span data-toggle="tooltip" title=""
-                      data-original-title={SnappyStructuredStreamingPage.tooltips("leftNavPanelTitle")}>
+                      data-original-title={
+                        SnappyStructuredStreamingPage.tooltips("leftNavPanelTitle")
+                      }>
                   { SnappyStructuredStreamingPage.leftNavPanelTitle }
                 </span>
               </th>
@@ -95,7 +95,7 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
   private def createSourcesTable: Seq[Node] = {
     <div style="width:100%;">
       <table id="querySourcesGrid" class="table table-bordered table-condensed"
-             style="background-color: #DDD; /*margin: 0px !important;*/">
+             style="background-color: #DDD;">
         <thead>
           <tr>
             <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
@@ -124,7 +124,9 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
             </th>
             <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
               <span data-toggle="tooltip" title=""
-                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcProcessingRate")}>
+                    data-original-title={
+                      SnappyStructuredStreamingPage.tooltips("srcProcessingRate")
+                    }>
                 { SnappyStructuredStreamingPage.streamingStats("srcProcessingRate") }
               </span>
             </th>
@@ -137,7 +139,7 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
   private def createSinkTable: Seq[Node] = {
     <div style="width:100%;">
       <table id="querySinkGrid" class="table table-bordered table-condensed"
-             style="background-color: #DDD; /*margin: 0px !important;*/">
+             style="background-color: #DDD;">
         <thead>
           <tr>
             <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
@@ -165,7 +167,6 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
   }
 
   private def createQueryDetailsEntry (): Seq[Node] = {
-
     <div id="querydetails">
       <div class="container-fluid details-section">
         <div id="selectedQueryTitle" data-toggle="tooltip" title=""
@@ -221,7 +222,9 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
         <div class="stats-block">
           <div>
             <div class="stats-block-title" data-toggle="tooltip" title=""
-                 data-original-title={SnappyStructuredStreamingPage.tooltips("currInputRowsPerSec")}>
+                 data-original-title={
+                   SnappyStructuredStreamingPage.tooltips("currInputRowsPerSec")
+                 }>
               { SnappyStructuredStreamingPage.streamingStats("currInputRowsPerSec") }
             </div>
             <div id="currInputRowsPerSec" class="stats-block-value">&nbsp;</div>
@@ -230,7 +233,9 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
         <div class="stats-block">
           <div>
             <div class="stats-block-title" data-toggle="tooltip" title=""
-                 data-original-title={SnappyStructuredStreamingPage.tooltips("currProcessedRowsPerSec")}>
+                 data-original-title={
+                   SnappyStructuredStreamingPage.tooltips("currProcessedRowsPerSec")
+                 }>
               { SnappyStructuredStreamingPage.streamingStats("currProcessedRowsPerSec") }
             </div>
             <div id="currProcessedRowsPerSec" class="stats-block-value">&nbsp;</div>
@@ -239,7 +244,9 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
         <div class="stats-block">
           <div>
             <div class="stats-block-title" data-toggle="tooltip" title=""
-                 data-original-title={SnappyStructuredStreamingPage.tooltips("totalProcessingTime")}>
+                 data-original-title={
+                   SnappyStructuredStreamingPage.tooltips("totalProcessingTime")
+                 }>
               { SnappyStructuredStreamingPage.streamingStats("totalProcessingTime") }
             </div>
             <div id="totalProcessingTime" class="stats-block-value">&nbsp;</div>
@@ -275,7 +282,8 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
       </div>
       <div class="container-fluid details-section">
         <div style="width: 5%;display: inline-block;border: 1px #8e8e8e solid;"></div>
-        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;" data-toggle="tooltip" title=""
+        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;"
+             data-toggle="tooltip" title=""
              data-original-title={SnappyStructuredStreamingPage.tooltips("sources")}>
           { SnappyStructuredStreamingPage.sourcesTitle }
         </div>
@@ -287,7 +295,8 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
       </div>
       <div class="container-fluid details-section">
         <div style="width: 5%;display: inline-block;border: 1px #8e8e8e solid;"></div>
-        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;" data-toggle="tooltip" title=""
+        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;"
+             data-toggle="tooltip" title=""
              data-original-title={SnappyStructuredStreamingPage.tooltips("sink")}>
           { SnappyStructuredStreamingPage.sinkTitle }
         </div>
@@ -332,14 +341,17 @@ object SnappyStructuredStreamingPage {
   tooltips += ("status" -> "Streaming query status (Active / Inactive)")
   tooltips += ("totalInputRows" -> "Total number of input records received since execution started")
   tooltips += ("currInputRowsPerSec" -> "Records / second received in current trigger interval")
-  tooltips += ("currProcessedRowsPerSec" -> "Records processed / second in current trigger interval")
-  tooltips += ("totalProcessingTime" -> "Total processing time of all batches received since execution is started")
+  tooltips += ("currProcessedRowsPerSec" ->
+                  "Records processed / second in current trigger interval")
+  tooltips += ("totalProcessingTime" ->
+                  "Total processing time of all batches received since execution is started")
   tooltips += ("avgProcessingTime" -> "Average processing time per batch")
   tooltips += ("sources" -> "Streaming queries sources")
   tooltips += ("srcType" -> "Type of streaming query source")
   tooltips += ("srcDescription" -> "Description of streaming query source")
   tooltips += ("srcInputRecords" -> "Number of records received from source in current interval")
-  tooltips += ("srcInputRate" -> "Number of records / second received from source in current interval")
+  tooltips += ("srcInputRate" ->
+                  "Number of records / second received from source in current interval")
   tooltips += ("srcProcessingRate" -> "Number of records processed / second in current interval")
   tooltips += ("sink" -> "Streaming queries sink")
   tooltips += ("snkDescription" -> "Description of streaming query sink")

--- a/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
@@ -183,14 +183,21 @@ private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
             <div id="startDateTime" class="basic-details-value">&nbsp;</div>
           </div>
           <div>
-            <div class="basic-details-title" data-toggle="tooltip" title=""
+            <div class="basic-details-title" style="width: 30%;" data-toggle="tooltip" title=""
                  data-original-title={SnappyStructuredStreamingPage.tooltips("uptime")}>
               { SnappyStructuredStreamingPage.streamingStats("uptime") }
             </div>
             <div id="uptime" class="basic-details-value">&nbsp;</div>
           </div>
           <div>
-            <div class="basic-details-title" style="width: 50%;" data-toggle="tooltip" title=""
+            <div class="basic-details-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("triggerInterval")}>
+              { SnappyStructuredStreamingPage.streamingStats("triggerInterval") }
+            </div>
+            <div id="triggerInterval" class="basic-details-value">&nbsp;</div>
+          </div>
+          <div>
+            <div class="basic-details-title" data-toggle="tooltip" title=""
                  data-original-title={SnappyStructuredStreamingPage.tooltips("batchesProcessed")}>
               { SnappyStructuredStreamingPage.streamingStats("batchesProcessed") }
             </div>
@@ -316,6 +323,7 @@ object SnappyStructuredStreamingPage {
   streamingStats += ("startDateTime" -> "Start Date & Time")
   streamingStats += ("uptime" -> "Uptime")
   streamingStats += ("status" -> "Status")
+  streamingStats += ("triggerInterval" -> "Trigger Interval")
   streamingStats += ("batchesProcessed" -> "Batches Processed")
   streamingStats += ("totalInputRows" -> "Total Input Records")
   streamingStats += ("currInputRowsPerSec" -> "Current Input Rate")
@@ -335,6 +343,7 @@ object SnappyStructuredStreamingPage {
   tooltips += ("queryName" -> "Streaming Query Name")
   tooltips += ("startDateTime" -> "Date & time when streaming query started its execution")
   tooltips += ("uptime" -> "Total time since streaming query started its execution")
+  tooltips += ("triggerInterval" -> "Configured triggering interval for batches")
   tooltips += ("batchesProcessed" -> "Number of batches processed since execution its started")
   tooltips += ("status" -> "Streaming query status (Active / Inactive)")
   tooltips += ("totalInputRows" -> "Total number of input records received since execution started")

--- a/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/ui/SnappyStructuredStreamingPage.scala
@@ -1,0 +1,354 @@
+/*
+ * Changes for SnappyData data platform.
+ *
+ * Portions Copyright (c) 2017-2019 TIBCO Software Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package org.apache.spark.ui
+
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.Node
+
+import org.apache.spark.internal.Logging
+
+// scalastyle:off
+
+private[ui] class SnappyStructuredStreamingPage(parent: SnappyStreamingTab)
+    extends WebUIPage("") with Logging {
+
+  val activeQueries = parent.listener.activeQueries
+
+  def commonHeaderNodesSnappy: Seq[Node] = {
+    <link rel="stylesheet" type="text/css"
+          href={UIUtils.prependBaseUri("/static/snappydata/snappy-streaming.css")}/>
+    <script src={UIUtils.prependBaseUri("/static/snappydata/d3.js")}></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src={UIUtils.prependBaseUri("/static/snappydata/jquery.sparkline.min.js")}></script>
+    <script src={UIUtils.prependBaseUri("/static/snappydata/snappy-commons.js")}></script>
+    <script src={UIUtils.prependBaseUri("/static/snappydata/snappy-streaming.js")}></script>
+  }
+
+  override def render(request: HttpServletRequest): Seq[Node] = {
+
+    val pageHeaderText: String = SnappyStructuredStreamingPage.pageHeaderText
+
+    val mainContent = {
+      val connErrorMsgNode = {
+        <div id="AutoUpdateErrorMsgContainer">
+          <div id="AutoUpdateErrorMsg">
+          </div>
+        </div>
+      }
+      connErrorMsgNode ++ createMainContent
+    }
+
+    val pageContent = commonHeaderNodesSnappy ++ mainContent
+
+    UIUtils.headerSparkPage(pageHeaderText, pageContent, parent, Some(500), useDataTables = true)
+
+  }
+
+  private def createMainContent: Seq[Node] = {
+    val navPanel = createNavigationPanel
+    val detailsPanel = createQueryDetailsPanel
+
+    <div class="main-container">
+      {navPanel ++ detailsPanel}
+    </div>
+  }
+
+  private def createNavigationPanel: Seq[Node] = {
+    <div class="left-navigation-panel">
+      <div style="width:100%;">
+        <table id="streamingQueriesGrid" class="table table-bordered table-condensed"
+               style="background-color: #bdbdbd; margin: 0px !important;">
+          <thead>
+            <tr>
+              <th class="table-th-col-heading" style="font-size: medium;">
+                <span data-toggle="tooltip" title=""
+                      data-original-title={SnappyStructuredStreamingPage.tooltips("leftNavPanelTitle")}>
+                  { SnappyStructuredStreamingPage.leftNavPanelTitle }
+                </span>
+              </th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+    </div>
+  }
+
+  private def createSourcesTable: Seq[Node] = {
+    <div style="width:100%;">
+      <table id="querySourcesGrid" class="table table-bordered table-condensed"
+             style="background-color: #DDD; /*margin: 0px !important;*/">
+        <thead>
+          <tr>
+            <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcType")}>
+                { SnappyStructuredStreamingPage.streamingStats("srcType") }
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="font-size: medium;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcDescription")}>
+                { SnappyStructuredStreamingPage.streamingStats("srcDescription") }
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcInputRecords")}>
+                { SnappyStructuredStreamingPage.streamingStats("srcInputRecords") }
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcInputRate")}>
+                { SnappyStructuredStreamingPage.streamingStats("srcInputRate") }
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("srcProcessingRate")}>
+                { SnappyStructuredStreamingPage.streamingStats("srcProcessingRate") }
+              </span>
+            </th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  }
+
+  private def createSinkTable: Seq[Node] = {
+    <div style="width:100%;">
+      <table id="querySinkGrid" class="table table-bordered table-condensed"
+             style="background-color: #DDD; /*margin: 0px !important;*/">
+        <thead>
+          <tr>
+            <th class="table-th-col-heading" style="font-size: medium; width: 200px;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("snkType")}>
+                { SnappyStructuredStreamingPage.streamingStats("snkType") }
+              </span>
+            </th>
+            <th class="table-th-col-heading" style="font-size: medium;">
+              <span data-toggle="tooltip" title=""
+                    data-original-title={SnappyStructuredStreamingPage.tooltips("snkDescription")}>
+                { SnappyStructuredStreamingPage.streamingStats("snkDescription") }
+              </span>
+            </th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  }
+
+  private def createQueryDetailsPanel: Seq[Node] = {
+    <div class="right-details-panel">
+      {createQueryDetailsEntry}
+    </div>
+  }
+
+  private def createQueryDetailsEntry (): Seq[Node] = {
+
+    <div id="querydetails">
+      <div class="container-fluid details-section">
+        <div id="selectedQueryTitle" data-toggle="tooltip" title=""
+             data-original-title={SnappyStructuredStreamingPage.tooltips("queryName")}>
+          { SnappyStructuredStreamingPage.streamingStats("queryName") }:
+        </div>
+        <div id="selectedQueryName"></div>
+      </div>
+      <div class="container-fluid details-section">
+        <div class="basic-details">
+          <div>
+            <div class="basic-details-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("startDateTime")}>
+              { SnappyStructuredStreamingPage.streamingStats("startDateTime") }
+            </div>
+            <div id="startDateTime" class="basic-details-value">&nbsp;</div>
+          </div>
+          <div>
+            <div class="basic-details-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("uptime")}>
+              { SnappyStructuredStreamingPage.streamingStats("uptime") }
+            </div>
+            <div id="uptime" class="basic-details-value">&nbsp;</div>
+          </div>
+          <div>
+            <div class="basic-details-title" style="width: 50%;" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("batchesProcessed")}>
+              { SnappyStructuredStreamingPage.streamingStats("batchesProcessed") }
+            </div>
+            <div id="numBatchesProcessed" class="basic-details-value">&nbsp;</div>
+          </div>
+        </div>
+      </div>
+      <div class="container-fluid details-section">
+        <div class="stats-block" style="width: 14%;">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("status")}>
+              { SnappyStructuredStreamingPage.streamingStats("status") }
+            </div>
+            <div id="status" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+        <div class="stats-block">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("totalInputRows")}>
+              { SnappyStructuredStreamingPage.streamingStats("totalInputRows") }
+            </div>
+            <div id="totalInputRows" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+        <div class="stats-block">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("currInputRowsPerSec")}>
+              { SnappyStructuredStreamingPage.streamingStats("currInputRowsPerSec") }
+            </div>
+            <div id="currInputRowsPerSec" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+        <div class="stats-block">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("currProcessedRowsPerSec")}>
+              { SnappyStructuredStreamingPage.streamingStats("currProcessedRowsPerSec") }
+            </div>
+            <div id="currProcessedRowsPerSec" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+        <div class="stats-block">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("totalProcessingTime")}>
+              { SnappyStructuredStreamingPage.streamingStats("totalProcessingTime") }
+            </div>
+            <div id="totalProcessingTime" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+        <div class="stats-block">
+          <div>
+            <div class="stats-block-title" data-toggle="tooltip" title=""
+                 data-original-title={SnappyStructuredStreamingPage.tooltips("avgProcessingTime")}>
+              { SnappyStructuredStreamingPage.streamingStats("avgProcessingTime") }
+            </div>
+            <div id="avgProcessingTime" class="stats-block-value">&nbsp;</div>
+          </div>
+        </div>
+      </div>
+      <div class="container-fluid" style="text-align: center;">
+        <div id="googleChartsErrorMsg"
+             style="text-align: center; color: #ff0f3f; display:none;">
+          { SnappyStructuredStreamingPage.googleChartsErrorMsg }
+        </div>
+      </div>
+      <div class="container-fluid details-section">
+        <div id="inputTrendsContainer" class="graph-container">
+        </div>
+        <div id="processingTrendContainer" class="graph-container">
+        </div>
+        <div id="processingTimeContainer" class="graph-container">
+        </div>
+        <div id="stateOperatorContainer" class="graph-container">
+        </div>
+        <!-- <div id="delayTrendContainer" class="graph-container">
+        </div> -->
+      </div>
+      <div class="container-fluid details-section">
+        <div style="width: 5%;display: inline-block;border: 1px #8e8e8e solid;"></div>
+        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;" data-toggle="tooltip" title=""
+             data-original-title={SnappyStructuredStreamingPage.tooltips("sources")}>
+          { SnappyStructuredStreamingPage.sourcesTitle }
+        </div>
+        <div style="width: 84%;display: inline-block;border: 1px #8e8e8e solid;"></div>
+      </div>
+      <div id="sourcesDetailsContainer" class="container-fluid details-section"
+           style="margin: 10px;">
+        { createSourcesTable }
+      </div>
+      <div class="container-fluid details-section">
+        <div style="width: 5%;display: inline-block;border: 1px #8e8e8e solid;"></div>
+        <div style="width: 10%;display: inline-block;font-size: 20px;font-weight: bold;" data-toggle="tooltip" title=""
+             data-original-title={SnappyStructuredStreamingPage.tooltips("sink")}>
+          { SnappyStructuredStreamingPage.sinkTitle }
+        </div>
+        <div style="width: 84%;display: inline-block;border: 1px #8e8e8e solid;"></div>
+      </div>
+      <div id="sinkDetailsContainer" class="container-fluid details-section"
+           style="/*height: 100px;*/ border: 1px solid grey; padding: 10px; margin: 10px;">
+        { createSinkTable }
+      </div>
+    </div>
+  }
+}
+
+object SnappyStructuredStreamingPage {
+  val pageHeaderText = "Structured Streaming Queries"
+
+  val streamingStats = scala.collection.mutable.HashMap.empty[String, Any]
+  streamingStats += ("queryName" -> "Query Name")
+  streamingStats += ("startDateTime" -> "Start Date & Time")
+  streamingStats += ("uptime" -> "Uptime")
+  streamingStats += ("status" -> "Status")
+  streamingStats += ("batchesProcessed" -> "Batches Processed")
+  streamingStats += ("totalInputRows" -> "Total Input Records")
+  streamingStats += ("currInputRowsPerSec" -> "Current Input Rate")
+  streamingStats += ("currProcessedRowsPerSec" -> "Current Processing Rate")
+  streamingStats += ("totalProcessingTime" -> "Total Batch Processing Time")
+  streamingStats += ("avgProcessingTime" -> "Avg. Batch Processing Time")
+  streamingStats += ("srcType" -> "Type")
+  streamingStats += ("srcDescription" -> "Description")
+  streamingStats += ("srcInputRecords" -> "Input Records")
+  streamingStats += ("srcInputRate" -> "Input Rate")
+  streamingStats += ("srcProcessingRate" -> "Processing Rate")
+  streamingStats += ("snkType" -> "Type")
+  streamingStats += ("snkDescription" -> "Description")
+
+  val tooltips = scala.collection.mutable.HashMap.empty[String, String]
+  tooltips += ("leftNavPanelTitle" -> "Streaming Query Names")
+  tooltips += ("queryName" -> "Streaming Query Name")
+  tooltips += ("startDateTime" -> "Date & time when streaming query started its execution")
+  tooltips += ("uptime" -> "Total time since streaming query started its execution")
+  tooltips += ("batchesProcessed" -> "Number of batches processed since execution its started")
+  tooltips += ("status" -> "Streaming query status (Active / Inactive)")
+  tooltips += ("totalInputRows" -> "Total number of input records received since execution started")
+  tooltips += ("currInputRowsPerSec" -> "Records / second received in current trigger interval")
+  tooltips += ("currProcessedRowsPerSec" -> "Records processed / second in current trigger interval")
+  tooltips += ("totalProcessingTime" -> "Total processing time of all batches received since execution is started")
+  tooltips += ("avgProcessingTime" -> "Average processing time per batch")
+  tooltips += ("sources" -> "Streaming queries sources")
+  tooltips += ("srcType" -> "Type of streaming query source")
+  tooltips += ("srcDescription" -> "Description of streaming query source")
+  tooltips += ("srcInputRecords" -> "Number of records received from source in current interval")
+  tooltips += ("srcInputRate" -> "Number of records / second received from source in current interval")
+  tooltips += ("srcProcessingRate" -> "Number of records processed / second in current interval")
+  tooltips += ("sink" -> "Streaming queries sink")
+  tooltips += ("snkDescription" -> "Description of streaming query sink")
+  tooltips += ("snkType" -> "Type of streaming query sink")
+
+  val googleChartsErrorMsg = "Error while loading charts. Please check your internet connection."
+
+  val leftNavPanelTitle = "Query Names"
+  val sourcesTitle = "Sources"
+  val sinkTitle = "Sink"
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -208,9 +208,11 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.name === event.name)
+      assert(newEvent.trigger === event.trigger)
     }
 
-    testSerialization(new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, "name"))
+    testSerialization(new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, "name",
+      ProcessingTime("1 second")))
     testSerialization(new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, null))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implementation of the Structure Streaming UI Tab to let users monitor the structured streaming query/application statistics and progress .
Structured Streaming Tab is available both in SnappyData embedded cluster as well as in smart connector application (using Snappy Spark distribution)

Structured Streaming Tab has below capabilities:
 - Listing all Structured Streaming Queries/Applications submitted to SnappyData cluster using submit-job command. Similarly in smart connector this tab will list streaming queries executed in cluster.
 - Allows user selecting queries from left hand side navigation panel, to view details view on right side main query details panel.
 - Query details panel displays selected queries details and statistics, as listed below;
   -- Query Name if provided, Query Id otherwise
   -- Start Date & Time
   -- Up time
   -- Trigger Interval
   -- Batches Processed
   -- Status
   -- Total Input Records
   -- Current Input Rate
   -- Current Processing Rate
   -- Total Batch Processing Time
   -- Avg. Batch Processing Time
 - Query details panel also lists sources of streaming query along with each source details like type, description, input records, input and processing rate
 - Query details panel also displays sink details of streaming query.
 - Query details panel depicts structured streaming queries behaviourial trends using following
   -- Input Records on every batch
   -- Input Rate vs Processing Rate
   -- Processing Time
   -- Aggregation State, if available

Please check JIRA item SNAP-2919 for UI screenshots (https://jira.snappydata.io/browse/SNAP-2919)

## How was this patch tested?

 - Tested manually

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
