### PR TITLE
Change the maxTaskFailures depending on property

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -194,7 +194,18 @@ private[spark] class TaskSchedulerImpl(
     val tasks = taskSet.tasks
     logInfo("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
     this.synchronized {
-      val manager = createTaskSetManager(taskSet, maxTaskFailures)
+      val maxRetryAttemptsForWrite = taskSet.properties.
+        getProperty("snappydata.maxRetryAttemptsForWrite")
+
+      logInfo("The maxRetryAttemptsForWrite is set to " + maxRetryAttemptsForWrite +
+        "maxTaskFailure " + maxTaskFailures)
+      val maxRetryAttempts = if (maxRetryAttemptsForWrite != null) {
+        maxRetryAttemptsForWrite.toInt
+      } else {
+        maxTaskFailures
+      }
+
+      val manager = createTaskSetManager(taskSet, maxRetryAttempts)
       val stage = taskSet.stageId
       val stageTaskSets =
         taskSetsByStageIdAndAttempt.getOrElseUpdate(stage, new HashMap[Int, TaskSetManager])

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -82,6 +82,8 @@ private[spark] class TaskSchedulerImpl(
   // How often to check for speculative tasks
   val SPECULATION_INTERVAL_MS = conf.getTimeAsMs("spark.speculation.interval", "100ms")
 
+  val SNAPPY_WRITE_RETRY_PROP = "snappydata.maxRetryAttemptsForWrite"
+
   // Duplicate copies of a task will only be launched if the original copy has been running for
   // at least this amount of time. This is to avoid the overhead of launching speculative copies
   // of tasks that are very short.
@@ -195,7 +197,7 @@ private[spark] class TaskSchedulerImpl(
     logInfo("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
     this.synchronized {
       val maxRetryAttemptsForWrite = taskSet.properties.
-        getProperty("snappydata.maxRetryAttemptsForWrite")
+        getProperty(SNAPPY_WRITE_RETRY_PROP)
 
       logInfo("The maxRetryAttemptsForWrite is set to " + maxRetryAttemptsForWrite +
         "maxTaskFailure " + maxTaskFailures)


### PR DESCRIPTION
The local propery is set based on plan from snappy side
If the propery is set, then maxTaskFailures is set to the set value

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
