### PR TITLE
Added change for initial metric name from TIBCO ComputeDB to TIBCO_Co…

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -137,7 +137,7 @@ private[spark] class MetricsSystem private (
         // ignoring <app ID>.<executor ID (or "driver")> instead of
         // that added unique clusterId along with sourceName
         if (source.sourceName.contains("TIBCO ComputeDB")) {
-          MetricRegistry.name("", "", "TIBCO_ComputeDB.")
+          MetricRegistry.name("", "", source.sourceName.replace(" ", "_"))
         } else if (source.sourceName.contains("SnappyData")) {
           MetricRegistry.name("", "", source.sourceName)
         } else {

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -133,13 +133,12 @@ private[spark] class MetricsSystem private (
 
     if (instance == "driver" || instance == "executor") {
       if (metricsNamespace.isDefined && executorId.isDefined) {
-        // If sourceName contains either TIBCO ComputeDB or SnappyData then
-        // ignoring <app ID>.<executor ID (or "driver")> instead of
-        // that added unique clusterId along with sourceName
-        if (source.sourceName.contains("TIBCO ComputeDB")) {
+        if (source.sourceName.contains("TIBCO ComputeDB") ||
+            source.sourceName.contains("SnappyData")) {
+          // If sourceName contains either TIBCO ComputeDB or SnappyData then
+          // ignoring <app ID>.<executor ID (or "driver")> instead of
+          // that added unique clusterId along with sourceName
           MetricRegistry.name("", "", source.sourceName.replace(" ", "_"))
-        } else if (source.sourceName.contains("SnappyData")) {
-          MetricRegistry.name("", "", source.sourceName)
         } else {
           // for default spark metrics namespace
           MetricRegistry.name(metricsNamespace.get, executorId.get, source.sourceName)

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -133,11 +133,12 @@ private[spark] class MetricsSystem private (
 
     if (instance == "driver" || instance == "executor") {
       if (metricsNamespace.isDefined && executorId.isDefined) {
-        if (source.sourceName.contains("TIBCO ComputeDB") ||
-            source.sourceName.contains("SnappyData")) {
-          // If sourceName contains either TIBCO ComputeDB or SnappyData then
-          // ignoring <app ID>.<executor ID (or "driver")> instead of
-          // that added unique clusterId along with sourceName
+        // If sourceName contains either TIBCO ComputeDB or SnappyData then
+        // ignoring <app ID>.<executor ID (or "driver")> instead of
+        // that added unique clusterId along with sourceName
+        if (source.sourceName.contains("TIBCO ComputeDB")) {
+          MetricRegistry.name("", "", "TIBCO_ComputeDB.")
+        } else if (source.sourceName.contains("SnappyData")) {
           MetricRegistry.name("", "", source.sourceName)
         } else {
           // for default spark metrics namespace


### PR DESCRIPTION
…mputeDB

## What changes were proposed in this pull request?
Added change for initial metric name from TIBCO ComputeDB to TIBCO_ComputeDB

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
