### PR TITLE
[SNAP 3268] Passing trigger interval as long value instead of entire Trigger object

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -246,7 +246,9 @@ class StreamExecution(
       }
 
       // `postEvent` does not throw non fatal exception.
-      postEvent(new QueryStartedEvent(id, runId, name, trigger))
+
+      postEvent(new QueryStartedEvent(id, runId, name,
+        trigger.asInstanceOf[ProcessingTime].intervalMs))
 
       // Unblock starting thread
       startLatch.countDown()

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
@@ -40,7 +40,7 @@ class SnappyStreamingQueryListener(sparkContext: SparkContext) extends Streaming
         queryName,
         event.runId,
         System.currentTimeMillis(),
-        event.trigger))
+        event.triggerInterval))
   }
 
   override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -97,7 +97,7 @@ object StreamingQueryListener {
       val id: UUID,
       val runId: UUID,
       val name: String,
-      val trigger: Trigger = ProcessingTime(0L)) extends Event
+      val triggerInterval: Long = 0L) extends Event
 
   /**
    * :: Experimental ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingRepository.scala
@@ -97,7 +97,7 @@ class StreamingQueryStatistics (
     qName: String,
     runId: UUID,
     startTime: Long,
-    trigger: Trigger = ProcessingTime(0L)) {
+    triggerInterval: Long) {
 
   private val MAX_SAMPLE_SIZE =
     SparkSession.getActiveSession.get.sqlContext.conf.streamingUITrendsMaxSampleSize
@@ -114,7 +114,7 @@ class StreamingQueryStatistics (
   var queryUptimeText: String = ""
 
   var runUUID: UUID = runId
-  val trendEventsInterval: Long = trigger.asInstanceOf[ProcessingTime].intervalMs
+  val trendEventsInterval: Long = triggerInterval
 
   var isActive: Boolean = true
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -208,11 +208,11 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.name === event.name)
-      assert(newEvent.trigger === event.trigger)
+      assert(newEvent.triggerInterval === event.triggerInterval)
     }
 
     testSerialization(new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, "name",
-      ProcessingTime("1 second")))
+      ProcessingTime("1 second").intervalMs))
     testSerialization(new QueryStartedEvent(UUID.randomUUID, UUID.randomUUID, null))
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of recent structured streaming UI, we introduced a new field for
`Trigger` in `QueryStartedEvent`. This field was added to retrieve the configured
trigger interval which can be displayed on UI on one of the charts.

Since `org.apache.spark.sql.streaming.Trigger` is a trait, JSON deserialization
of the same will require custom deserialization logic. Writing the same will be
overkill as ultimately the `Trigger` object has only one implementation as
of now which `ProcessingTime` and all `ProcessingTime` contains is trigger
interval which of `Long` type. Hence instead of passing the whole object as
part of the event, we are now passing only the trigger interval.

## How was this patch tested?
- failing test is passing now
- running precheckin with -Pspark