### PR TITLE
[SNAP-3270] removing streaming query listener in finalize method

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -72,7 +72,6 @@ import org.apache.spark.util.Utils
  * }}}
  */
 @InterfaceStability.Stable
-@SuppressWarnings("unchecked")
 class SparkSession private(
     @transient val sparkContext: SparkContext,
     @transient private val existingSharedState: Option[SharedState])

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -71,6 +71,7 @@ import org.apache.spark.util.Utils
  *     .getOrCreate()
  * }}}
  */
+// scalastyle:off no.finalize
 @InterfaceStability.Stable
 class SparkSession private(
     @transient val sparkContext: SparkContext,
@@ -751,10 +752,9 @@ class SparkSession private(
   // lifecycle. After this the listener object will be eligible for GC in the next cycle.
   // Also the memory footprint of the listener object is not much hence it should be ok if the
   // listener object is remain alive for one extra GC cycle as compared to the session.
-  override def finalize(): Unit = {
-    sessionState.removeStreamingQueryListener()
-  }
+  override def finalize(): Unit = sessionState.removeStreamingQueryListener()
 }
+// scalastyle:on no.finalize
 
 
 @InterfaceStability.Stable

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -72,12 +72,11 @@ import org.apache.spark.util.Utils
  * }}}
  */
 @InterfaceStability.Stable
+@SuppressWarnings("unchecked")
 class SparkSession private(
     @transient val sparkContext: SparkContext,
     @transient private val existingSharedState: Option[SharedState])
   extends Serializable with Closeable with Logging { self =>
-
-  private var ssqListener: SnappyStreamingQueryListener = null
 
   private[sql] def this(sc: SparkContext) {
     this(sc, None)
@@ -720,9 +719,9 @@ class SparkSession private(
    * All session instances have their own SnappyStreamingQueryListener but shares same UI tab.
    */
   protected def updateUIWithStructuredStreamingTab() = {
-    ssqListener = new SnappyStreamingQueryListener()
-    this.streams.addListener(ssqListener)
-
+    val listener = new SnappyStreamingQueryListener()
+    this.streams.addListener(listener)
+    sessionState.registerStreamingQueryListener(listener)
     if (sparkContext.ui.isDefined) {
       logInfo("Updating Web UI to add structure streaming tab.")
       sparkContext.ui.foreach(ui => {
@@ -742,23 +741,20 @@ class SparkSession private(
           // Streaming web service
           ui.attachHandler(SnappyStreamingApiRootResource.getServletHandler(ui))
           // Streaming tab
-          new SnappyStreamingTab(ui, ssqListener)
+          new SnappyStreamingTab(ui, listener)
         }
       })
       logInfo("Updating Web UI to add structure streaming tab is Done.")
     }
   }
 
-  // scalastyle:off
   // Doing this clean up in finalize method as lifecycle of the listener is aligned with session's
-  // lifecycle and can't think of any better place where this cleanup can be handled. After this
-  // the listener object will be eligible for GC in the next cycle.
+  // lifecycle. After this the listener object will be eligible for GC in the next cycle.
   // Also the memory footprint of the listener object is not much hence it should be ok if the
   // listener object is remain alive for one extra GC cycle as compared to the session.
   override def finalize(): Unit = {
-    sessionState.streamingQueryManager.removeListener(ssqListener)
+    sessionState.removeStreamingQueryListener()
   }
-  // scalastyle:on
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -21,7 +21,6 @@ import java.io.File
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
@@ -32,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.AnalyzeTableCommand
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryManager}
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener, StreamingQueryManager}
 import org.apache.spark.sql.util.ExecutionListenerManager
 
 
@@ -151,6 +150,19 @@ private[sql] class SessionState(sparkSession: SparkSession) {
    */
   lazy val streamingQueryManager: StreamingQueryManager = {
     new StreamingQueryManager(sparkSession)
+  }
+
+  /**
+    * Listener for streaming query UI
+    */
+  private var streamingQueryListener: StreamingQueryListener = _
+
+  def registerStreamingQueryListener(streamingQueryListener: StreamingQueryListener): Unit = {
+    this.streamingQueryListener = streamingQueryListener
+  }
+
+  def removeStreamingQueryListener(): Unit = {
+    streamingQueryManager.removeListener(streamingQueryListener)
   }
 
   private val jarClassLoader: NonClosableMutableURLClassLoader =

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/SnappyStreamingQueryListener.scala
@@ -19,11 +19,9 @@
 
 package org.apache.spark.sql.streaming
 
-import org.apache.spark.SparkContext
+class SnappyStreamingQueryListener extends StreamingQueryListener {
 
-class SnappyStreamingQueryListener(sparkContext: SparkContext) extends StreamingQueryListener {
-
-  val streamingRepo = StreamingRepository.getInstance
+  private val streamingRepo = StreamingRepository.getInstance
 
   override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
     val queryName = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -45,6 +45,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
 
   after {
     spark.streams.active.foreach(_.stop())
+    // finalize method removes the StreamingQueryListener registered for structured streaming UI.
+    spark.finalize()
     assert(spark.streams.active.isEmpty)
     assert(addedListeners().isEmpty)
     // Make sure we don't leak any events to the next test


### PR DESCRIPTION
## What changes were proposed in this pull request?

For streaming UI, `SnappyStreamingQueryListener` is registered on listener bus
at the time of creating `SnappySession`. However, this listener is never removed
from the listener bus. Hence even if the `SnappySession` is collected by GC,
`SnappyStreamingQueryListener` is left orphan on the listener bus which is never
eligible for GC collection.

To fix this we are removing the listener from the listener bus when the session
the instance is getting collected by GC (i.e. in finalize method) which will make
the listener instance eligible for GC during the next GC cycle.

It should be OK if the listener instance gets collected in the next GC cycle as the
the memory footprint of the listener object is not big.

Another possible place to remove the listener in `close` method of the session,
however close method of session is not required to be closed explicitly.

## How was this patch tested?

Reproduced the issue by running the following code as part of a snappy job: 

```
while(true){
      session.newSession()
}
```

Collected histogram of leader process using `jmap` and observed that instances of
`SnappyStreamingQueryListener` is increasing indefinitely and never garbage
collected whereas `SnappySession` instances are garbage collected: 

`jmap -histo:live <leader pid>|grep "SnappySession\|SnappyStreamingQueryListener"`

Followed the same steps after applying the changes and noticed that
 `SnappyStreamingQueryListener` instances are garbage collected.

--- 

- precheckin -Pspark
- `SnappyStreamingQueryListenerSuite` is passing now. Added a call to `finalize`
method in `StreamingQueryListenerSuite` to get this change tested.



