### PR TITLE
SNAP-3273 : Structured Streaming UI displays only 10 queries at a time.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-dashboard.js
@@ -252,7 +252,7 @@ function getMemberStatsGridConf() {
   var memberStatsGridConf = {
     data: memberStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
-    "iDisplayLength": 50,
+    "pageLength": 50,
     "columns": [
       { // Expand/Collapse Button
         data: function(row, type) {
@@ -368,7 +368,7 @@ function getTableStatsGridConf() {
   var tableStatsGridConf = {
     data: tableStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
-    "iDisplayLength": 50,
+    "pageLength": 50,
     "columns": [
       { // Name
         data: function(row, type) {
@@ -488,7 +488,7 @@ function getExternalTableStatsGridConf() {
   var extTableStatsGridConf = {
     data: extTableStatsGridData,
     "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
-    "iDisplayLength": 50,
+    "pageLength": 50,
     "columns": [
       { // Name
         data: function(row, type) {

--- a/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/snappydata/snappy-streaming.js
@@ -250,7 +250,7 @@ function updateCharts(queryStats) {
   };
 
   stateOperatorsStatsChartOptions = {
-    title: 'Aggregation States',
+    title: 'Aggregation State',
     // curveType: 'function',
     legend: { position: 'bottom' },
     colors:['#2139EC'],
@@ -299,6 +299,7 @@ function getQuerySourcesGridConf() {
   // Streaming Queries Source Grid Data Table Configurations
   var querySourcesGridConf = {
     data: selectedQuerySourcesGridData,
+    "pageLength": -1,
     "dom": '',
     "columns": [
       { // Source type
@@ -373,6 +374,7 @@ function getQuerySinkGridConf() {
   // Streaming Queries Sink Grid Data Table Configurations
   var querySinkGridConf = {
     data: selectedQuerySinkGridData,
+    "pageLength": -1,
     "dom": '',
     "columns": [
       { // Sink type
@@ -402,6 +404,7 @@ function getStreamingQueriesGridConf() {
   // Streaming Queries Grid Data Table Configurations
   var streamingQueriesGridConf = {
     data: streamingQueriesGridData,
+    "pageLength": -1,
     "dom": '',
     "columns": [
       { // Query Names


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem:** The default limit for number of streaming query to be displayed is 20. But in the current UI, only 10 queries are displayed. The rest of the queries are displayed when we click on the sort button.

**Changes:**
 - Data Table config parameter name is changed from "_iDisplayLength_" to "_pageLength_".
 - Streaming Queries navigation list, sources and sink tables config parameter "_pageLength_" is
   set to display all entries in it.  
 - Chart title changed from "_Aggregation States_" to "_Aggregation State_"

## How was this patch tested?

 - Tested manually and by running streaming program with KAFKA.

Please review http://spark.apache.org/contributing.html before opening a pull request.
